### PR TITLE
[codex] fix grok imagine image generation routing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "st-chatu8",
+  "version": "2.7.5",
+  "type": "module",
+  "scripts": {
+    "test": "node --test tests/grokImageFetchAdapter.test.mjs"
+  }
+}

--- a/tests/grokImageFetchAdapter.test.mjs
+++ b/tests/grokImageFetchAdapter.test.mjs
@@ -1,0 +1,134 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildGrokImageRequest,
+  convertImageGenerationResponse,
+  installGrokImageFetchAdapter,
+} from '../utils/grokImageFetchAdapter.js';
+
+test('rewrites direct grok image chat requests to images generations', async () => {
+  const rewrite = await buildGrokImageRequest(
+    'http://127.0.0.1:8084/v1/chat/completions',
+    {
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer test-key',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: 'grok-imagine-image',
+        messages: [
+          { role: 'system', content: 'ignore this system prompt' },
+          {
+            role: 'user',
+            content: [
+              { type: 'image_url', image_url: { url: 'data:image/png;base64,aaa' } },
+              { type: 'text', text: 'a red apple on a white table' },
+            ],
+          },
+        ],
+      }),
+    },
+  );
+
+  assert.equal(rewrite.url, 'http://127.0.0.1:8084/v1/images/generations');
+  assert.equal(rewrite.init.method, 'POST');
+  assert.equal(rewrite.init.headers.get('authorization'), 'Bearer test-key');
+  assert.deepEqual(JSON.parse(rewrite.init.body), {
+    model: 'grok-imagine-image',
+    prompt: 'a red apple on a white table',
+    n: 1,
+    response_format: 'b64_json',
+  });
+});
+
+test('does not rewrite non-grok image models', async () => {
+  const rewrite = await buildGrokImageRequest(
+    'http://127.0.0.1:8084/v1/chat/completions',
+    {
+      method: 'POST',
+      body: JSON.stringify({
+        model: 'gpt-4o-mini',
+        messages: [{ role: 'user', content: 'hello' }],
+      }),
+    },
+  );
+
+  assert.equal(rewrite, null);
+});
+
+test('rewrites SillyTavern proxy requests using the configured custom url and headers', async () => {
+  const rewrite = await buildGrokImageRequest(
+    '/api/backends/chat-completions/generate',
+    {
+      method: 'POST',
+      body: JSON.stringify({
+        model: 'grok-imagine-image',
+        custom_url: 'http://127.0.0.1:8084/v1',
+        custom_include_headers: 'Authorization: Bearer proxy-key',
+        messages: [{ role: 'user', content: 'a blue cup on a wood desk' }],
+      }),
+    },
+  );
+
+  assert.equal(rewrite.url, 'http://127.0.0.1:8084/v1/images/generations');
+  assert.equal(rewrite.init.headers.get('authorization'), 'Bearer proxy-key');
+  assert.deepEqual(JSON.parse(rewrite.init.body), {
+    model: 'grok-imagine-image',
+    prompt: 'a blue cup on a wood desk',
+    n: 1,
+    response_format: 'b64_json',
+  });
+});
+
+test('converts image generation b64 responses to chat image content', () => {
+  const converted = convertImageGenerationResponse(
+    {
+      id: 'image-id',
+      created: 123,
+      data: [{ b64_json: 'abc123' }],
+    },
+    'grok-imagine-image',
+  );
+
+  assert.equal(converted.id, 'image-id');
+  assert.equal(converted.object, 'chat.completion');
+  assert.equal(converted.model, 'grok-imagine-image');
+  assert.equal(
+    converted.choices[0].message.content[0].image_url.url,
+    'data:image/png;base64,abc123',
+  );
+});
+
+test('installed adapter returns chat-shaped image content from rewritten fetches', async () => {
+  const calls = [];
+  const fakeGlobal = {
+    Headers,
+    Response,
+    fetch: async (url, init) => {
+      calls.push({ url, init });
+      return new Response(JSON.stringify({ data: [{ b64_json: 'abc123' }] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    },
+  };
+
+  installGrokImageFetchAdapter(fakeGlobal);
+
+  const response = await fakeGlobal.fetch('http://127.0.0.1:8084/v1/chat/completions', {
+    method: 'POST',
+    body: JSON.stringify({
+      model: 'grok-imagine-image',
+      messages: [{ role: 'user', content: 'a green vase' }],
+    }),
+  });
+  const body = await response.json();
+
+  assert.equal(calls[0].url, 'http://127.0.0.1:8084/v1/images/generations');
+  assert.equal(
+    body.choices[0].message.content[0].image_url.url,
+    'data:image/png;base64,abc123',
+  );
+});

--- a/utils/grokImageFetchAdapter.js
+++ b/utils/grokImageFetchAdapter.js
@@ -1,0 +1,250 @@
+const GROK_IMAGE_MODEL_PREFIX = /^grok-imagine/i;
+
+function getHeaderCtor(globalObject = globalThis) {
+  return globalObject?.Headers || globalThis.Headers;
+}
+
+function getResponseCtor(globalObject = globalThis) {
+  return globalObject?.Response || globalThis.Response;
+}
+
+function getRequestUrl(input) {
+  if (typeof input === 'string') return input;
+  if (input instanceof URL) return input.toString();
+  if (input && typeof input.url === 'string') return input.url;
+  return '';
+}
+
+function getRequestMethod(input, init = {}) {
+  return String(init?.method || input?.method || 'GET').toUpperCase();
+}
+
+function getRequestHeaders(input, init = {}, globalObject = globalThis) {
+  const HeadersCtor = getHeaderCtor(globalObject);
+  return new HeadersCtor(init?.headers || input?.headers || {});
+}
+
+async function getRequestBodyText(input, init = {}) {
+  const body = init?.body;
+
+  if (typeof body === 'string') return body;
+  if (body instanceof Uint8Array) return new TextDecoder().decode(body);
+  if (body instanceof ArrayBuffer) return new TextDecoder().decode(body);
+  if (body && typeof body.text === 'function') return body.text();
+
+  if (input && typeof input.clone === 'function') {
+    try {
+      return await input.clone().text();
+    } catch {
+      return '';
+    }
+  }
+
+  return '';
+}
+
+function parseJson(text) {
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+function stripWrappingQuotes(value) {
+  const trimmed = String(value || '').trim();
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1).trim();
+  }
+  return trimmed;
+}
+
+function applyCustomHeaders(headers, rawHeaders) {
+  if (!rawHeaders || typeof rawHeaders !== 'string') return;
+
+  for (const line of rawHeaders.split(/\r?\n/)) {
+    const match = line.match(/^([^:]+):\s*(.*)$/);
+    if (!match) continue;
+    headers.set(match[1].trim(), stripWrappingQuotes(match[2]));
+  }
+}
+
+function extractTextFromContent(content) {
+  if (typeof content === 'string') return content.trim();
+  if (Array.isArray(content)) {
+    return content
+      .map((part) => {
+        if (typeof part === 'string') return part;
+        if (!part || typeof part !== 'object') return '';
+        if (part.type === 'text') return part.text || part.content || '';
+        return '';
+      })
+      .filter(Boolean)
+      .join('\n')
+      .trim();
+  }
+  if (content && typeof content === 'object') {
+    return String(content.text || content.content || '').trim();
+  }
+  return '';
+}
+
+function extractPrompt(body) {
+  if (typeof body?.prompt === 'string' && body.prompt.trim()) {
+    return body.prompt.trim();
+  }
+
+  if (!Array.isArray(body?.messages)) return '';
+
+  for (let index = body.messages.length - 1; index >= 0; index -= 1) {
+    const message = body.messages[index];
+    if (message?.role !== 'user') continue;
+    const text = extractTextFromContent(message.content);
+    if (text) return text;
+  }
+
+  for (let index = body.messages.length - 1; index >= 0; index -= 1) {
+    const text = extractTextFromContent(body.messages[index]?.content);
+    if (text) return text;
+  }
+
+  return '';
+}
+
+function isChatCompletionsUrl(url) {
+  return /\/chat\/completions(?:[?#].*)?$/i.test(url);
+}
+
+function isSillyTavernChatProxyUrl(url) {
+  return /\/api\/backends\/chat-completions\/generate(?:[?#].*)?$/i.test(url);
+}
+
+function appendImagesGenerations(baseUrl) {
+  return String(baseUrl || '').replace(/\/+$/, '') + '/images/generations';
+}
+
+function getImageGenerationUrl(url, body) {
+  if (typeof body?.custom_url === 'string' && body.custom_url.trim()) {
+    return appendImagesGenerations(body.custom_url.trim());
+  }
+
+  return String(url).replace(/\/chat\/completions(?:[?#].*)?$/i, '/images/generations');
+}
+
+function getModel(body) {
+  return body?.model || body?.custom_model || body?.image_model || '';
+}
+
+export async function buildGrokImageRequest(input, init = {}, globalObject = globalThis) {
+  const url = getRequestUrl(input);
+  const method = getRequestMethod(input, init);
+
+  if (!url || method !== 'POST') return null;
+  if (!isChatCompletionsUrl(url) && !isSillyTavernChatProxyUrl(url)) return null;
+
+  const body = parseJson(await getRequestBodyText(input, init));
+  const model = getModel(body);
+  if (!GROK_IMAGE_MODEL_PREFIX.test(String(model))) return null;
+
+  const prompt = extractPrompt(body);
+  if (!prompt) return null;
+
+  const headers = getRequestHeaders(input, init, globalObject);
+  applyCustomHeaders(headers, body.custom_include_headers);
+  headers.set('content-type', 'application/json');
+
+  const count = Number(body.n || body.num_images || 1);
+  const payload = {
+    model,
+    prompt,
+    n: Number.isFinite(count) && count > 0 ? count : 1,
+    response_format: 'b64_json',
+  };
+
+  return {
+    url: getImageGenerationUrl(url, body),
+    init: {
+      ...init,
+      method: 'POST',
+      headers,
+      body: JSON.stringify(payload),
+    },
+  };
+}
+
+export function convertImageGenerationResponse(result, model) {
+  const firstImage = result?.data?.[0] || {};
+  const imageUrl = firstImage.b64_json
+    ? `data:image/png;base64,${firstImage.b64_json}`
+    : firstImage.url;
+
+  if (!imageUrl) {
+    throw new Error('Grok image response did not include b64_json or url');
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  return {
+    id: result.id || `grok-image-${now}`,
+    object: 'chat.completion',
+    created: result.created || now,
+    model,
+    choices: [
+      {
+        index: 0,
+        finish_reason: 'stop',
+        message: {
+          role: 'assistant',
+          content: [
+            {
+              type: 'image_url',
+              image_url: {
+                url: imageUrl,
+              },
+            },
+          ],
+        },
+      },
+    ],
+    usage: result.usage,
+  };
+}
+
+export function installGrokImageFetchAdapter(globalObject = globalThis) {
+  if (!globalObject || globalObject.__stChatu8GrokImageFetchAdapterInstalled) return false;
+  if (typeof globalObject.fetch !== 'function') return false;
+
+  const originalFetch = globalObject.fetch.bind(globalObject);
+  const ResponseCtor = getResponseCtor(globalObject);
+  if (!ResponseCtor) return false;
+
+  globalObject.fetch = async (input, init = {}) => {
+    const rewrite = await buildGrokImageRequest(input, init, globalObject);
+    if (!rewrite) return originalFetch(input, init);
+
+    const imageResponse = await originalFetch(rewrite.url, rewrite.init);
+    if (!imageResponse.ok) return imageResponse;
+
+    const imageResult = await imageResponse.clone().json();
+    const imagePayload = JSON.parse(rewrite.init.body);
+    const chatResult = convertImageGenerationResponse(imageResult, imagePayload.model);
+
+    return new ResponseCtor(JSON.stringify(chatResult), {
+      status: imageResponse.status,
+      statusText: imageResponse.statusText,
+      headers: {
+        'content-type': 'application/json',
+      },
+    });
+  };
+
+  globalObject.__stChatu8GrokImageFetchAdapterInstalled = true;
+  return true;
+}
+
+if (typeof window !== 'undefined') {
+  installGrokImageFetchAdapter(window);
+}


### PR DESCRIPTION
## Summary
- Route grok-imagine image model requests that go through chat/proxy endpoints to /v1/images/generations.
- Wrap image generation responses back into chat.completion image_url content for the existing plugin parser.
- Add focused adapter tests and an npm test script.

## Root cause
The grok-imagine-image model works through /v1/images/generations, but fails when the plugin sends it through /v1/chat/completions or the SillyTavern chat proxy path.

## Validation
- npm test: 5 tests passed
- node --check index.js
- node --check utils/grokImageFetchAdapter.js
- Live plugin-style request through the configured Aether URL returned HTTP 200, object=chat.completion, and a data:image/png;base64 image URL prefix
