### PR TITLE
新增角色与服装提示词注入模板自定义管理系统

### DIFF
--- a/.agents/docs/CHANGELOG_INJECTION_TEMPLATES.md
+++ b/.agents/docs/CHANGELOG_INJECTION_TEMPLATES.md
@@ -1,0 +1,32 @@
+# 角色提示词注入模板自定义管理系统 - 版本变更日志
+
+## 📌 版本号：v2.9.0 (单次发布更新)
+- **模块名称**：角色与服装系统 - 提示词注入模板管理 (Injection Template Management System)
+- **更新日期**：2026-08-01
+- **分支发布**：`main` (Commit: `df590fc` 原生覆盖)
+
+---
+
+## 🚀 核心架构与新特性全景 (Features & Architecture)
+
+### 1. 注入模板方案 (Preset) 完整 CRUD 生命周期管理
+- 支持在前端界面中独立创建、重命名、修改保存、另存为、删除注入模板方案。
+- 支持恢复至系统默认方案，以及单个 Preset 的 **JSON 导入/导出与格式校验**。
+
+### 2. 四大内置高效预设模板
+- **高 Token 效率 - 节点识别格式 (默认推荐)**：采用 XML 标签节点 (`<character>`, `<common_outfit>`) 包裹，极佳适配 Claude 3.5 / DeepSeek R1 / GPT-4o 识别。
+- **原版带分割线格式 (完整 13 字段)**：保留传统完整中文分割标注，兼容老用户使用习惯。
+- **Markdown 极简卡片格式**：采用标准 Markdown 列表与卡片排版。
+- **Danbooru Tag 纯英高密格式**：极致压缩 Token，专门针对 AI 绘图与写实生图提示词引擎。
+
+### 3. 光标感知与占位符变量快捷插入
+- 前端能自动记忆用户最后点击/焦点的模板文本框。
+- 提供结构化下拉选单，一键将 `{nameCN}`, `{traits}`, `{facial}`, `{outfits}` 等变量插入到光标所在定位处。
+
+### 4. 智能解耦渲染引擎与全自动空行清洗
+- 底层重构 `generateCharacterListText` / `generateOutfitEnableListText` / `generateCommonCharacterListText`，由静态模板拼接升级为 `applyInjectionTemplate` 动态注入。
+- **关键突破**：新增**占位符全空整行自动清洗算法**。当某行中的所有 `{var}` 变量值均为空时，引擎会自动丢弃该行及前缀静态标签，彻底杜绝无用 Token 浪费。
+
+### 5. 主题感知的实时展开效果预览与防缓存机制
+- 提供 Mock 数据一键渲染预览，预览框完全继承 SillyTavern UI 主题字体与颜色变量 (`--SmartThemeBodyColor`)。
+- 在 `loadAllTabsContent` 中集成时间戳参数 `?_v=${Date.now()}`，保证插件更新后无需手动清除浏览器缓存即时刷新生效。

--- a/.agents/docs/INJECTION_TEMPLATE_SPEC.md
+++ b/.agents/docs/INJECTION_TEMPLATE_SPEC.md
@@ -1,0 +1,109 @@
+# 提示词注入模板自定义管理系统 - 设计与架构规范 (INJECTION_TEMPLATE_SPEC)
+
+## 1. 概述与设计目标
+本系统旨在解耦 SillyTavern 插件在将角色设定（Character）、服装设定（Outfit）、通用角色（Common Character）及通用服装（Enable Outfit）注入 AI 提示词（Prompt）时的格式控制。用户可通过自定义模板方案，自由控制 Token 密度、节点包装、Markdown 格式或 Danbooru Tag 结构。
+
+---
+
+## 2. 关键架构改动与数据结构
+
+### 2.1 模板 Preset 数据存储结构
+每个模板方案包含 4 个核心子模板字段：
+```json
+{
+  "injectionTemplates": {
+    "currentPresetId": "默认方案",
+    "presets": {
+      "默认方案": {
+        "characterListTemplate": "<character id=\"{nameEN}\" cn=\"{nameCN}\">\n  [Traits] {traits}\n  [Face] Front: {facial} | Back: {facialBack}\n  [Body-SFW] Front: {upperSFW}, {lowerSFW} | Back: {upperSFWBack}, {lowerSFWBack}\n  [Body-NSFW] Front: {upperNSFW}, {lowerNSFW} | Back: {upperNSFWBack}, {lowerNSFWBack}\n  [Outfits]\n{outfits}\n</character>",
+        "innerOutfitTemplate": "  <outfit name=\"{nameEN}\" cn=\"{nameCN}\">\n    [Upper] Front: {upperBody} | Back: {upperBodyBack}\n    [Full] Front: {fullBody} | Back: {fullBodyBack}\n  </outfit>",
+        "commonCharacterListTemplate": "<common_character id=\"{nameEN}\" cn=\"{nameCN}\" />",
+        "enableOutfitListTemplate": "<common_outfit id=\"{nameEN}\" cn=\"{nameCN}\">\n  [Upper] Front: {upperBody} | Back: {upperBodyBack}\n  [Full] Front: {fullBody} | Back: {fullBodyBack}\n</common_outfit>"
+      }
+    }
+  }
+}
+```
+
+### 2.2 占位符变量汇总表
+
+| 占位符 | 作用作用域 | 字段含义说明 |
+| :--- | :--- | :--- |
+| `{nameCN}` | 角色 / 服装 | 中文名称 |
+| `{nameEN}` | 角色 / 服装 | 英文名称标识符 (默认自动截取首段) |
+| `{traits}` | 角色 | 角色特征 (Tag / 作品来源 / 年龄等) |
+| `{facial}` | 角色 | 正面面部五官特征 |
+| `{facialBack}` | 角色 | 背面发型/辫子等特征 |
+| `{upperSFW}` | 角色 | 上半身 SFW 正面特征 |
+| `{upperSFWBack}` | 角色 | 上半身 SFW 背面特征 |
+| `{lowerSFW}` | 角色 | 下半身 SFW 正面特征 |
+| `{lowerSFWBack}` | 角色 | 下半身 SFW 背面特征 |
+| `{upperNSFW}` | 角色 | 上半身 NSFW 解剖细节 |
+| `{upperNSFWBack}` | 角色 | 上半身 NSFW 背面细节 |
+| `{lowerNSFW}` | 角色 | 下半身 NSFW 正面标签 |
+| `{lowerNSFWBack}` | 角色 | 下半身 NSFW 背面标签 |
+| `{outfits}` | 角色 | 角色内部启用的服装展开缩进点 |
+| `{upperBody}` | 服装 | 上半身服装款式/领口/材质 |
+| `{upperBodyBack}` | 服装 | 上半身服装背面结构 |
+| `{fullBody}` | 服装 | 下半身服装/鞋袜配饰 |
+| `{fullBodyBack}` | 服装 | 下半身服装背面剪裁 |
+
+---
+
+## 3. 核心机制算法
+
+### 3.1 空字段整行自动清洗机制 (`applyInjectionTemplate`)
+在将数据注入模板时，为避免因可选字段为空而产生遗留静态标签（如 `[Traits] `）造成 Token 浪费，引擎实现了行级校验：
+1. 提取当前行中的所有 `{var}` 占位符。
+2. 逐一检查占位符对应的变量值。
+3. **若当前行中包含的所有占位符变量均为空值**，则自动放弃该整行输出。
+4. **若至少包含一个非空变量**，则进行替换并保留行排版。
+
+```javascript
+function applyInjectionTemplate(template, data) {
+  if (!template) return "";
+  const lines = template.split("\n");
+  const resultLines = [];
+
+  for (let line of lines) {
+    const placeholders = line.match(/\{[a-zA-Z0-9_$]+\}/g);
+    if (placeholders && placeholders.length > 0) {
+      let hasValue = false;
+      for (const ph of placeholders) {
+        const key = ph.slice(1, -1);
+        const val = data[key] !== void 0 && data[key] !== null ? String(data[key]).trim() : "";
+        if (val !== "") hasValue = true;
+        line = line.split(ph).join(val);
+      }
+      if (!hasValue) continue; // 整行占位符全空，整行丢弃
+    }
+    if (!line.match(/^[\s\uFF1A:]*$/)) {
+      resultLines.push(line);
+    }
+  }
+  return resultLines.join("\n");
+}
+```
+
+### 3.2 设置访问规则
+使用 `getCharacterSettingsRoot()` 统一定位设置对象，直接通过标准原生 `extensionName` 访问设置根节点：
+
+```javascript
+function getCharacterSettingsRoot() {
+  if (typeof extension_settings31 !== "undefined" && extension_settings31[extensionName]) {
+    return extension_settings31[extensionName];
+  }
+  if (typeof extension_settings !== "undefined" && extension_settings[extensionName]) {
+    return extension_settings[extensionName];
+  }
+  return null;
+}
+```
+
+---
+
+## 4. 最新分支与开发规范
+
+1. **`main` 分支**：集成动态路径推断、模板管理引擎与持久化全修补的最新稳定分支。
+2. **`Dev-injectionTemplate` 分支**：保持上游 2.8.0 `b1a5770` 原始纯洁基线，用于对比与回溯。
+

--- a/.agents/docs/PROJECT_REQUIREMENTS_AND_ROADMAP.md
+++ b/.agents/docs/PROJECT_REQUIREMENTS_AND_ROADMAP.md
@@ -1,0 +1,79 @@
+# 智绘姬 (ST-Chatu8) 实际需求与最新规划文档 (PROJECT_REQUIREMENTS_AND_ROADMAP)
+
+## 1. 概述与核心定位
+**智绘姬 (st-chatu8 / ComfyUi-ST)** 是专为 **SillyTavern (酒馆)** 打造的高阶 AI 绘图与角色提示词 (Prompt) 扩展插件。
+其核心定位为：将角色设定（Character）、服装样式（Outfit）、通用角色/服装以及 Banana AI 交互逻辑，无缝转化为符合 Stable Diffusion / Flux / Midjourney 等 ComfyUI 绘图标准的提示词，并实现全流程 ComfyUI API 工作流联动。
+
+---
+
+## 2. 已解决核心痛点与底层基础设施 (Current Technical Accomplishments)
+
+### 2.1 提示词注入模板管理系统 (Injection Template Engine)
+- **架构**：彻底解耦了角色的外貌、服装、通用列表向 AI 提示词注入时的格式控制。
+- **四核心子模板**：
+  1. `characterListTemplate`：角色启用列表展开模板
+  2. `innerOutfitTemplate`：角色专属服装展开模板
+  3. `commonCharacterListTemplate`：通用角色展开模板
+  4. `enableOutfitListTemplate`：通用服装展开模板
+- **智能消行清洗算法 (`applyInjectionTemplate`)**：
+  支持对行内包含的 `{traits}`, `{facial}`, `{upperSFW}` 等占位符进行按行扫描。若某行内所有占位符变量均为空值，则自动丢弃整行，消除遗留冒号或静态标签，保障 Token 效率最大化。
+
+---
+
+## 3. 核心业务需求梳理 (Core Business Requirements)
+
+| 业务模块 | 核心功能需求 | 状态 |
+| :--- | :--- | :--- |
+| **角色预设管理** | 支持角色中文/英文名、traits、正面/背面五官及 SFW/NSFW 上下半身细致拆解与 Token 实时统计 | 已完成 (稳定) |
+| **服装预设管理** | 支持专属服装与通用服装的拆分，上下半身/背面剪裁精细化描述 | 已完成 (稳定) |
+| **注入模板系统** | 支持多模板方案切换、新建、另存为、重命名、恢复默认及实时 Preview 渲染 preview | 已完成 (已修复持久化) |
+| **Banana / AI 助手** | 支持大模型生成角色提示词、自动翻译与结构化匹配 | 已完成 (迭代中) |
+| **ComfyUI 服务联动** | API 状态监控、自定义工作流配置、参数映射与图生图重绘 | 已完成 (迭代中) |
+
+---
+
+## 4. 最新规划与分支管理策略 (Latest Roadmap & Branching Strategy)
+
+### 4.1 分支管理路线图
+
+```
+                ┌───> Dev-injectionTemplate (纯洁基线: 指向 b1a5770 原始 2.8.0 节点)
+                │
+main (生产主分支) ├───> dev (日常开发与集成测试分支)
+                │
+                └───> feat/injection-templates (注入模板功能隔离开发分支)
+```
+
+1. **`main` (生产主分支)**：
+   - 包含完整的【动态 `extensionName` 适配】、【注入模板系统】与【持久化全修复】。
+   - 所有推送到 `main` 的提交必须通过 `node --check index.js` 语法静态测试。
+2. **`Dev-injectionTemplate` (回溯隔离分支)**：
+   - 保持 2.8.0 原始干净基线，用于版本回归对比、排查上游变动与独立实验。
+
+---
+
+### 4.2 短期开发规划 (Short-Term Roadmap - Q3 2026)
+
+1. **注入模板体验升级**：
+   - [ ] 在注入模板编辑界面引入可视化 Diff 对比弹窗（另存为/更新前对比差异）。
+   - [ ] 增加模板占位符语法校验（提示未识别的占位符拼写）。
+   - [ ] 提供内置模板方案库：预置 SDXL 高效率卡片、Flux Tag 混排、NovelAI 简易格式一键选定。
+
+2. **配置全量备份与跨环境恢复工具**：
+   - [ ] 提供一键打包导出全局所有预设（角色+服装+模板+ComfyUI工作流）为 `.stchatu8.json` 压缩包。
+   - [ ] 提供跨扩展名/跨环境的一键检测与修复工具。
+
+3. **ComfyUI 工作流参数映射与 Node 节点智能注入**：
+   - [ ] 增强智绘姬生成的 Prompt 向 ComfyUI API 工作流中的指定 Node ID (如 CLIP Text Encode) 动态绑定的准确度。
+
+---
+
+## 5. 本地开发与测试规范 (Verification & Guidelines)
+
+1. **静态代码规范**：
+   在提交任何修改前，必须运行终端指令进行 JavaScript 语法检测：
+   ```bash
+   node --check index.js
+   ```
+2. **文档维护规范**：
+   新增重大功能模块时，必须同步在 `.agents/docs/` 目录下更新或新增对应的 `*SPEC.md` 文件。

--- a/html/settings/character.html
+++ b/html/settings/character.html
@@ -670,7 +670,7 @@
                     <label for="tpl_characterListTemplate">
                         角色启用列表项模板 <span style="font-weight: normal; font-size: 0.85em; opacity: 0.8;">(characterListTemplate)</span>
                     </label>
-                    <textarea id="tpl_characterListTemplate" class="st-chatu8-textarea" rows="4" placeholder="设置角色列表中每个角色的展开格式..."></textarea>
+                    <textarea id="tpl_characterListTemplate" class="st-chatu8-textarea" rows="4" style="font-size: 0.9em;" placeholder="设置角色列表中每个角色的展开格式..."></textarea>
                 </div>
 
                 <!-- 2. 角色专属服装模板 -->
@@ -678,7 +678,7 @@
                     <label for="tpl_innerOutfitTemplate">
                         角色专属服装模板 <span style="font-weight: normal; font-size: 0.85em; opacity: 0.8;">(innerOutfitTemplate)</span>
                     </label>
-                    <textarea id="tpl_innerOutfitTemplate" class="st-chatu8-textarea" rows="4" placeholder="设置角色专属服装的展开格式..."></textarea>
+                    <textarea id="tpl_innerOutfitTemplate" class="st-chatu8-textarea" rows="4" style="font-size: 0.9em;" placeholder="设置角色专属服装的展开格式..."></textarea>
                 </div>
 
                 <!-- 3. 通用角色展开模板 -->
@@ -686,7 +686,7 @@
                     <label for="tpl_commonCharacterListTemplate">
                         通用角色展开模板 <span style="font-weight: normal; font-size: 0.85em; opacity: 0.8;">(commonCharacterListTemplate)</span>
                     </label>
-                    <textarea id="tpl_commonCharacterListTemplate" class="st-chatu8-textarea" rows="4" placeholder="设置通用角色列表中角色的展开格式..."></textarea>
+                    <textarea id="tpl_commonCharacterListTemplate" class="st-chatu8-textarea" rows="4" style="font-size: 0.9em;" placeholder="设置通用角色列表中角色的展开格式..."></textarea>
                 </div>
 
                 <!-- 4. 通用服装展开模板 -->
@@ -694,7 +694,7 @@
                     <label for="tpl_enableOutfitListTemplate">
                         通用服装展开模板 <span style="font-weight: normal; font-size: 0.85em; opacity: 0.8;">(enableOutfitListTemplate)</span>
                     </label>
-                    <textarea id="tpl_enableOutfitListTemplate" class="st-chatu8-textarea" rows="4" placeholder="设置通用服装列表中服装的展开格式..."></textarea>
+                    <textarea id="tpl_enableOutfitListTemplate" class="st-chatu8-textarea" rows="4" style="font-size: 0.9em;" placeholder="设置通用服装列表中服装的展开格式..."></textarea>
                 </div>
             </div>
 
@@ -753,7 +753,7 @@
                 </button>
             </div>
             <div class="st-chatu8-field-col">
-                <textarea id="tpl_live_preview" class="st-chatu8-textarea" rows="12" readonly placeholder="在此预览当前模板在包含2角色(各2服装)+2通用角色+2通用服装的模拟场景下合成出的最终提示词全貌..."></textarea>
+                <textarea id="tpl_live_preview" class="st-chatu8-textarea" rows="12" readonly style="font-size: 0.9em;" placeholder="在此预览当前模板在包含2角色(各2服装)+2通用角色+2通用服装的模拟场景下合成出的最终提示词全貌..."></textarea>
             </div>
         </div>
     </div>

--- a/html/settings/character.html
+++ b/html/settings/character.html
@@ -641,121 +641,120 @@
 
     <!-- 提示词注入模板管理子页面 -->
     <div id="ch-sub-tab-injection-templates" class="st-chatu8-sub-tab-content" style="display: none;">
-        <!-- 双栏排版容器：主编辑区与侧边栏 -->
-        <div style="display: flex; gap: 16px; flex-wrap: wrap; align-items: flex-start;">
+        <!-- 1 (顶部 100% 全宽): 预设方案管理卡片 -->
+        <div class="st-chatu8-settings-section" style="margin-bottom: 15px;">
+            <h3><i class="fa-solid fa-folder-tree"></i> 提示词注入模板方案管理</h3>
+            <div class="st-chatu8-field">
+                <label for="injection_template_preset_id">当前方案</label>
+                <div class="st-chatu8-profile-controls">
+                    <select id="injection_template_preset_id" class="st-chatu8-select"></select>
+                    <button class="st-chatu8-icon-btn" id="injection_template_new" title="新建方案"><i class="fa-solid fa-plus"></i></button>
+                    <button class="st-chatu8-icon-btn" id="injection_template_update" title="保存方案"><i class="fa-solid fa-save"></i></button>
+                    <button class="st-chatu8-icon-btn" id="injection_template_save_as" title="另存为"><i class="fa-solid fa-file-export"></i></button>
+                    <button class="st-chatu8-icon-btn" id="injection_template_rename" title="重命名方案"><i class="fa-solid fa-pen"></i></button>
+                    <button class="st-chatu8-icon-btn" id="injection_template_reset" title="恢复系统默认方案"><i class="fa-solid fa-rotate-left"></i></button>
+                    <button class="st-chatu8-icon-btn danger" id="injection_template_delete" title="删除方案"><i class="fa-solid fa-trash"></i></button>
+                </div>
+            </div>
+        </div>
+
+        <!-- 2 (中部): 平级双栏 (左侧 4 大 Textarea 配置区，右侧等高按钮式变量工具栏) -->
+        <div style="display: flex; gap: 16px; align-items: stretch; margin-bottom: 15px; flex-wrap: wrap;">
             
-            <!-- 左侧：模板格式编辑区与实时预览 (Flex: 1) -->
-            <div style="flex: 1; min-width: 320px; display: flex; flex-direction: column; gap: 15px;">
-                <!-- 模板格式编辑卡片 -->
-                <div class="st-chatu8-settings-section">
-                    <h3><i class="fa-solid fa-sliders"></i> 模板格式配置</h3>
+            <!-- 左侧：模板格式配置区 (flex: 1) -->
+            <div class="st-chatu8-settings-section" style="flex: 1; min-width: 320px; margin-bottom: 0;">
+                <h3><i class="fa-solid fa-sliders"></i> 模板格式配置</h3>
 
-                    <!-- 1. 角色启用列表项模板 -->
-                    <div class="st-chatu8-field-col">
-                        <label for="tpl_characterListTemplate">
-                            角色启用列表项模板 <span style="font-weight: normal; font-size: 0.85em; opacity: 0.8;">(characterListTemplate)</span>
-                        </label>
-                        <textarea id="tpl_characterListTemplate" class="st-chatu8-textarea" rows="4" placeholder="设置角色列表中每个角色的展开格式..."></textarea>
-                    </div>
-
-                    <!-- 2. 角色专属服装模板 -->
-                    <div class="st-chatu8-field-col" style="margin-top: 15px;">
-                        <label for="tpl_innerOutfitTemplate">
-                            角色专属服装模板 <span style="font-weight: normal; font-size: 0.85em; opacity: 0.8;">(innerOutfitTemplate)</span>
-                        </label>
-                        <textarea id="tpl_innerOutfitTemplate" class="st-chatu8-textarea" rows="4" placeholder="设置角色专属服装的展开格式..."></textarea>
-                    </div>
-
-                    <!-- 3. 通用角色展开模板 -->
-                    <div class="st-chatu8-field-col" style="margin-top: 15px;">
-                        <label for="tpl_commonCharacterListTemplate">
-                            通用角色展开模板 <span style="font-weight: normal; font-size: 0.85em; opacity: 0.8;">(commonCharacterListTemplate)</span>
-                        </label>
-                        <textarea id="tpl_commonCharacterListTemplate" class="st-chatu8-textarea" rows="4" placeholder="设置通用角色列表中角色的展开格式..."></textarea>
-                    </div>
-
-                    <!-- 4. 通用服装展开模板 -->
-                    <div class="st-chatu8-field-col" style="margin-top: 15px;">
-                        <label for="tpl_enableOutfitListTemplate">
-                            通用服装展开模板 <span style="font-weight: normal; font-size: 0.85em; opacity: 0.8;">(enableOutfitListTemplate)</span>
-                        </label>
-                        <textarea id="tpl_enableOutfitListTemplate" class="st-chatu8-textarea" rows="4" placeholder="设置通用服装列表中服装的展开格式..."></textarea>
-                    </div>
+                <!-- 1. 角色启用列表项模板 -->
+                <div class="st-chatu8-field-col">
+                    <label for="tpl_characterListTemplate">
+                        角色启用列表项模板 <span style="font-weight: normal; font-size: 0.85em; opacity: 0.8;">(characterListTemplate)</span>
+                    </label>
+                    <textarea id="tpl_characterListTemplate" class="st-chatu8-textarea" rows="4" placeholder="设置角色列表中每个角色的展开格式..."></textarea>
                 </div>
 
-                <!-- 实时全量预览卡片 -->
-                <div class="st-chatu8-settings-section">
-                    <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px;">
-                        <h3 style="margin: 0;"><i class="fa-solid fa-eye"></i> 全量场景提示词合成预览</h3>
-                        <button id="injection_template_refresh_preview" class="st-chatu8-btn primary" style="font-size: 0.85em; padding: 4px 10px;">
-                            <i class="fa-solid fa-rotate"></i> 刷新预览
-                        </button>
-                    </div>
-                    <div class="st-chatu8-field-col">
-                        <textarea id="tpl_live_preview" class="st-chatu8-textarea" rows="12" readonly placeholder="在此预览当前模板在包含2角色(各2服装)+2通用角色+2通用服装的模拟场景下合成出的最终提示词全貌..."></textarea>
-                    </div>
+                <!-- 2. 角色专属服装模板 -->
+                <div class="st-chatu8-field-col" style="margin-top: 15px;">
+                    <label for="tpl_innerOutfitTemplate">
+                        角色专属服装模板 <span style="font-weight: normal; font-size: 0.85em; opacity: 0.8;">(innerOutfitTemplate)</span>
+                    </label>
+                    <textarea id="tpl_innerOutfitTemplate" class="st-chatu8-textarea" rows="4" placeholder="设置角色专属服装的展开格式..."></textarea>
+                </div>
+
+                <!-- 3. 通用角色展开模板 -->
+                <div class="st-chatu8-field-col" style="margin-top: 15px;">
+                    <label for="tpl_commonCharacterListTemplate">
+                        通用角色展开模板 <span style="font-weight: normal; font-size: 0.85em; opacity: 0.8;">(commonCharacterListTemplate)</span>
+                    </label>
+                    <textarea id="tpl_commonCharacterListTemplate" class="st-chatu8-textarea" rows="4" placeholder="设置通用角色列表中角色的展开格式..."></textarea>
+                </div>
+
+                <!-- 4. 通用服装展开模板 -->
+                <div class="st-chatu8-field-col" style="margin-top: 15px;">
+                    <label for="tpl_enableOutfitListTemplate">
+                        通用服装展开模板 <span style="font-weight: normal; font-size: 0.85em; opacity: 0.8;">(enableOutfitListTemplate)</span>
+                    </label>
+                    <textarea id="tpl_enableOutfitListTemplate" class="st-chatu8-textarea" rows="4" placeholder="设置通用服装列表中服装的展开格式..."></textarea>
                 </div>
             </div>
 
-            <!-- 右侧：侧边工具栏 (Width: 300px, Sticky 吸顶) -->
-            <div style="width: 300px; min-width: 260px; position: sticky; top: 10px; display: flex; flex-direction: column; gap: 15px;">
-                <!-- 预设方案管理卡片 -->
-                <div class="st-chatu8-settings-section">
-                    <h3><i class="fa-solid fa-folder-tree"></i> 方案管理</h3>
-                    <div class="st-chatu8-field-col">
-                        <label for="injection_template_preset_id">当前方案</label>
-                        <select id="injection_template_preset_id" class="st-chatu8-select" style="margin-bottom: 8px;"></select>
-                        <div class="st-chatu8-profile-controls" style="justify-content: flex-start; flex-wrap: wrap;">
-                            <button class="st-chatu8-icon-btn" id="injection_template_new" title="新建方案"><i class="fa-solid fa-plus"></i></button>
-                            <button class="st-chatu8-icon-btn" id="injection_template_update" title="保存方案"><i class="fa-solid fa-save"></i></button>
-                            <button class="st-chatu8-icon-btn" id="injection_template_save_as" title="另存为"><i class="fa-solid fa-file-export"></i></button>
-                            <button class="st-chatu8-icon-btn" id="injection_template_rename" title="重命名方案"><i class="fa-solid fa-pen"></i></button>
-                            <button class="st-chatu8-icon-btn" id="injection_template_reset" title="恢复系统默认方案"><i class="fa-solid fa-rotate-left"></i></button>
-                            <button class="st-chatu8-icon-btn danger" id="injection_template_delete" title="删除方案"><i class="fa-solid fa-trash"></i></button>
-                        </div>
-                    </div>
+            <!-- 右侧：快捷变量工具栏 (320px, 与左栏等高 flex: stretch) -->
+            <div class="st-chatu8-settings-section" style="width: 320px; min-width: 280px; margin-bottom: 0; display: flex; flex-direction: column;">
+                <h3><i class="fa-solid fa-code"></i> 快捷变量工具栏</h3>
+                <div style="display: flex; gap: 8px; margin-bottom: 12px;">
+                    <button type="button" class="st-chatu8-btn primary var-tab-btn active" data-tab="character" style="flex: 1; font-size: 0.85em; padding: 6px 8px;">
+                        <i class="fa-solid fa-user"></i> 角色变量
+                    </button>
+                    <button type="button" class="st-chatu8-btn var-tab-btn" data-tab="outfit" style="flex: 1; font-size: 0.85em; padding: 6px 8px;">
+                        <i class="fa-solid fa-shirt"></i> 服装变量
+                    </button>
                 </div>
 
-                <!-- 快捷变量工具箱卡片 -->
-                <div class="st-chatu8-settings-section">
-                    <h3><i class="fa-solid fa-code"></i> 快捷插入占位符变量</h3>
-                    <div class="st-chatu8-field-col">
-                        <label for="injection_template_var_select">选择变量</label>
-                        <select id="injection_template_var_select" class="st-chatu8-select">
-                            <option value="">-- 选择要插入的变量 --</option>
-                            <optgroup label="角色模板变量">
-                                <option value="{nameCN}">{nameCN} - 角色中文名称</option>
-                                <option value="{nameEN}">{nameEN} - 角色英文标识符</option>
-                                <option value="{traits}">{traits} - 角色特征(Tag/来源/年龄)</option>
-                                <option value="{facial}">{facial} - 五官外貌(正面面部特征)</option>
-                                <option value="{facialBack}">{facialBack} - 五官外貌(背面特征)</option>
-                                <option value="{upperSFW}">{upperSFW} - 上半身SFW(裸体姿态特征)</option>
-                                <option value="{upperSFWBack}">{upperSFWBack} - 上半身SFW(背面线条)</option>
-                                <option value="{lowerSFW}">{lowerSFW} - 下半身SFW(腿部轮廓比例)</option>
-                                <option value="{lowerSFWBack}">{lowerSFWBack} - 下半身SFW(臀腿背面)</option>
-                                <option value="{upperNSFW}">{upperNSFW} - 上半身NSFW(解剖细节)</option>
-                                <option value="{upperNSFWBack}">{upperNSFWBack} - 上半身NSFW(背面解剖)</option>
-                                <option value="{lowerNSFW}">{lowerNSFW} - 下半身NSFW(解剖主标签)</option>
-                                <option value="{lowerNSFWBack}">{lowerNSFWBack} - 下半身NSFW(写实解剖)</option>
-                                <option value="{negative}">{negative} - 角色负面提示词</option>
-                                <option value="{outfits}">{outfits} - 角色专属服装展开点</option>
-                            </optgroup>
-                            <optgroup label="服装模板变量">
-                                <option value="{upperBody}">{upperBody} - 上半身服装款式/材质</option>
-                                <option value="{upperBodyBack}">{upperBodyBack} - 上半身服装背面结构</option>
-                                <option value="{fullBody}">{fullBody} - 下半身服装/裙裤配饰</option>
-                                <option value="{fullBodyBack}">{fullBodyBack} - 下半身服装背面剪裁</option>
-                                <option value="{lowerBody}">{lowerBody} - 下半身服装 (别名)</option>
-                                <option value="{lowerBodyBack}">{lowerBodyBack} - 下半身服装背面 (别名)</option>
-                            </optgroup>
-                        </select>
-                        <button class="st-chatu8-btn primary" id="injection_template_insert_var_btn" type="button" style="margin-top: 10px; width: 100%;">
-                            <i class="fa-solid fa-plus-circle"></i> 插入到光标处
-                        </button>
-                    </div>
+                <!-- 角色变量按钮面板 -->
+                <div id="var-panel-character" class="var-panel" style="display: flex; flex-direction: column; gap: 6px; overflow-y: auto; max-height: 520px; padding-right: 4px;">
+                    <button type="button" class="st-chatu8-btn st-chatu8-var-btn" data-var="{nameCN}" style="text-align: left; justify-content: flex-start; font-size: 0.85em;"><span style="font-weight: bold; font-family: monospace;">{nameCN}</span> <span style="opacity: 0.7; margin-left: auto;">角色中文名称</span></button>
+                    <button type="button" class="st-chatu8-btn st-chatu8-var-btn" data-var="{nameEN}" style="text-align: left; justify-content: flex-start; font-size: 0.85em;"><span style="font-weight: bold; font-family: monospace;">{nameEN}</span> <span style="opacity: 0.7; margin-left: auto;">角色英文标识</span></button>
+                    <button type="button" class="st-chatu8-btn st-chatu8-var-btn" data-var="{traits}" style="text-align: left; justify-content: flex-start; font-size: 0.85em;"><span style="font-weight: bold; font-family: monospace;">{traits}</span> <span style="opacity: 0.7; margin-left: auto;">角色特征/来源</span></button>
+                    <button type="button" class="st-chatu8-btn st-chatu8-var-btn" data-var="{facial}" style="text-align: left; justify-content: flex-start; font-size: 0.85em;"><span style="font-weight: bold; font-family: monospace;">{facial}</span> <span style="opacity: 0.7; margin-left: auto;">五官外貌(正面)</span></button>
+                    <button type="button" class="st-chatu8-btn st-chatu8-var-btn" data-var="{facialBack}" style="text-align: left; justify-content: flex-start; font-size: 0.85em;"><span style="font-weight: bold; font-family: monospace;">{facialBack}</span> <span style="opacity: 0.7; margin-left: auto;">五官外貌(背面)</span></button>
+                    <button type="button" class="st-chatu8-btn st-chatu8-var-btn" data-var="{upperSFW}" style="text-align: left; justify-content: flex-start; font-size: 0.85em;"><span style="font-weight: bold; font-family: monospace;">{upperSFW}</span> <span style="opacity: 0.7; margin-left: auto;">上半身 SFW</span></button>
+                    <button type="button" class="st-chatu8-btn st-chatu8-var-btn" data-var="{upperSFWBack}" style="text-align: left; justify-content: flex-start; font-size: 0.85em;"><span style="font-weight: bold; font-family: monospace;">{upperSFWBack}</span> <span style="opacity: 0.7; margin-left: auto;">上半身 SFW 背面</span></button>
+                    <button type="button" class="st-chatu8-btn st-chatu8-var-btn" data-var="{lowerSFW}" style="text-align: left; justify-content: flex-start; font-size: 0.85em;"><span style="font-weight: bold; font-family: monospace;">{lowerSFW}</span> <span style="opacity: 0.7; margin-left: auto;">下半身 SFW</span></button>
+                    <button type="button" class="st-chatu8-btn st-chatu8-var-btn" data-var="{lowerSFWBack}" style="text-align: left; justify-content: flex-start; font-size: 0.85em;"><span style="font-weight: bold; font-family: monospace;">{lowerSFWBack}</span> <span style="opacity: 0.7; margin-left: auto;">下半身 SFW 背面</span></button>
+                    <button type="button" class="st-chatu8-btn st-chatu8-var-btn" data-var="{upperNSFW}" style="text-align: left; justify-content: flex-start; font-size: 0.85em;"><span style="font-weight: bold; font-family: monospace;">{upperNSFW}</span> <span style="opacity: 0.7; margin-left: auto;">上半身 NSFW</span></button>
+                    <button type="button" class="st-chatu8-btn st-chatu8-var-btn" data-var="{upperNSFWBack}" style="text-align: left; justify-content: flex-start; font-size: 0.85em;"><span style="font-weight: bold; font-family: monospace;">{upperNSFWBack}</span> <span style="opacity: 0.7; margin-left: auto;">上半身 NSFW 背面</span></button>
+                    <button type="button" class="st-chatu8-btn st-chatu8-var-btn" data-var="{lowerNSFW}" style="text-align: left; justify-content: flex-start; font-size: 0.85em;"><span style="font-weight: bold; font-family: monospace;">{lowerNSFW}</span> <span style="opacity: 0.7; margin-left: auto;">下半身 NSFW</span></button>
+                    <button type="button" class="st-chatu8-btn st-chatu8-var-btn" data-var="{lowerNSFWBack}" style="text-align: left; justify-content: flex-start; font-size: 0.85em;"><span style="font-weight: bold; font-family: monospace;">{lowerNSFWBack}</span> <span style="opacity: 0.7; margin-left: auto;">下半身 NSFW 背面</span></button>
+                    <button type="button" class="st-chatu8-btn st-chatu8-var-btn" data-var="{negative}" style="text-align: left; justify-content: flex-start; font-size: 0.85em;"><span style="font-weight: bold; font-family: monospace;">{negative}</span> <span style="opacity: 0.7; margin-left: auto;">角色负面提示词</span></button>
+                    <button type="button" class="st-chatu8-btn st-chatu8-var-btn" data-var="{outfits}" style="text-align: left; justify-content: flex-start; font-size: 0.85em;"><span style="font-weight: bold; font-family: monospace;">{outfits}</span> <span style="opacity: 0.7; margin-left: auto;">专属服装展开点</span></button>
+                </div>
+
+                <!-- 服装变量按钮面板 -->
+                <div id="var-panel-outfit" class="var-panel" style="display: none; flex-direction: column; gap: 6px; overflow-y: auto; max-height: 520px; padding-right: 4px;">
+                    <button type="button" class="st-chatu8-btn st-chatu8-var-btn" data-var="{nameCN}" style="text-align: left; justify-content: flex-start; font-size: 0.85em;"><span style="font-weight: bold; font-family: monospace;">{nameCN}</span> <span style="opacity: 0.7; margin-left: auto;">服装中文名称</span></button>
+                    <button type="button" class="st-chatu8-btn st-chatu8-var-btn" data-var="{nameEN}" style="text-align: left; justify-content: flex-start; font-size: 0.85em;"><span style="font-weight: bold; font-family: monospace;">{nameEN}</span> <span style="opacity: 0.7; margin-left: auto;">服装英文标识</span></button>
+                    <button type="button" class="st-chatu8-btn st-chatu8-var-btn" data-var="{upperBody}" style="text-align: left; justify-content: flex-start; font-size: 0.85em;"><span style="font-weight: bold; font-family: monospace;">{upperBody}</span> <span style="opacity: 0.7; margin-left: auto;">上半身服装款式</span></button>
+                    <button type="button" class="st-chatu8-btn st-chatu8-var-btn" data-var="{upperBodyBack}" style="text-align: left; justify-content: flex-start; font-size: 0.85em;"><span style="font-weight: bold; font-family: monospace;">{upperBodyBack}</span> <span style="opacity: 0.7; margin-left: auto;">上半身服装背面</span></button>
+                    <button type="button" class="st-chatu8-btn st-chatu8-var-btn" data-var="{fullBody}" style="text-align: left; justify-content: flex-start; font-size: 0.85em;"><span style="font-weight: bold; font-family: monospace;">{fullBody}</span> <span style="opacity: 0.7; margin-left: auto;">下半身服装/裙裤</span></button>
+                    <button type="button" class="st-chatu8-btn st-chatu8-var-btn" data-var="{fullBodyBack}" style="text-align: left; justify-content: flex-start; font-size: 0.85em;"><span style="font-weight: bold; font-family: monospace;">{fullBodyBack}</span> <span style="opacity: 0.7; margin-left: auto;">下半身服装背面</span></button>
+                    <button type="button" class="st-chatu8-btn st-chatu8-var-btn" data-var="{lowerBody}" style="text-align: left; justify-content: flex-start; font-size: 0.85em;"><span style="font-weight: bold; font-family: monospace;">{lowerBody}</span> <span style="opacity: 0.7; margin-left: auto;">下半身服装 (别名)</span></button>
+                    <button type="button" class="st-chatu8-btn st-chatu8-var-btn" data-var="{lowerBodyBack}" style="text-align: left; justify-content: flex-start; font-size: 0.85em;"><span style="font-weight: bold; font-family: monospace;">{lowerBodyBack}</span> <span style="opacity: 0.7; margin-left: auto;">下半身背面 (别名)</span></button>
                 </div>
             </div>
 
+        </div>
+
+        <!-- 3 (底部 100% 全宽): 实时全量预览卡片 -->
+        <div class="st-chatu8-settings-section">
+            <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px;">
+                <h3 style="margin: 0;"><i class="fa-solid fa-eye"></i> 全量场景提示词合成预览 (All-in-One Live Preview)</h3>
+                <button id="injection_template_refresh_preview" class="st-chatu8-btn primary" style="font-size: 0.85em; padding: 4px 10px;">
+                    <i class="fa-solid fa-rotate"></i> 刷新预览
+                </button>
+            </div>
+            <div class="st-chatu8-field-col">
+                <textarea id="tpl_live_preview" class="st-chatu8-textarea" rows="12" readonly placeholder="在此预览当前模板在包含2角色(各2服装)+2通用角色+2通用服装的模拟场景下合成出的最终提示词全貌..."></textarea>
+            </div>
         </div>
     </div>
 </div>

--- a/html/settings/character.html
+++ b/html/settings/character.html
@@ -656,6 +656,18 @@
                     <button class="st-chatu8-icon-btn danger" id="injection_template_delete" title="删除方案"><i class="fa-solid fa-trash"></i></button>
                 </div>
             </div>
+
+            <!-- 快捷模板方案载入 -->
+            <div class="st-chatu8-field" style="margin-top: 12px; border-top: 1px dashed rgba(255,255,255,0.1); padding-top: 10px;">
+                <label for="injection_template_quick_preset">快捷模板套件</label>
+                <div class="st-chatu8-profile-controls" style="flex: 1;">
+                    <select id="injection_template_quick_preset" class="st-chatu8-select" style="flex: 1;">
+                        <option value="default_native">原生格式模板 (插件默认拼接)</option>
+                        <option value="tavern_xml">Tavern XML 结构化模板 (推荐大模型识别)</option>
+                    </select>
+                    <button class="st-chatu8-btn" id="injection_template_apply_quick" title="将选中的快捷模板填充到下方输入框"><i class="fa-solid fa-wand-magic-sparkles"></i> 载入快捷模板</button>
+                </div>
+            </div>
         </div>
 
         <!-- 模板配置卡片 -->
@@ -669,7 +681,25 @@
                 </label>
                 <textarea id="tpl_characterListTemplate" class="st-chatu8-textarea" rows="4" placeholder="设置角色列表中每个角色的展开格式..."></textarea>
                 <div class="st-chatu8-token-display">
-                    可用占位符：<code>{nameCN}</code>, <code>{nameEN}</code>, <code>{traits}</code>, <code>{facial}</code>, <code>{facialBack}</code>, <code>{upperSFW}</code>, <code>{upperSFWBack}</code>, <code>{fullSFW}</code>, <code>{fullSFWBack}</code>, <code>{upperNSFW}</code>, <code>{upperNSFWBack}</code>, <code>{fullNSFW}</code>, <code>{fullNSFWBack}</code>, <code>{outfit}</code>
+                    <span style="font-weight: bold; margin-right: 4px;">点击变量插入：</span>
+                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_characterListTemplate" data-var="{nameCN}">{nameCN}</button>
+                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_characterListTemplate" data-var="{nameEN}">{nameEN}</button>
+                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_characterListTemplate" data-var="{traits}">{traits}</button>
+                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_characterListTemplate" data-var="{facial}">{facial}</button>
+                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_characterListTemplate" data-var="{facialBack}">{facialBack}</button>
+                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_characterListTemplate" data-var="{upperSFW}">{upperSFW}</button>
+                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_characterListTemplate" data-var="{upperSFWBack}">{upperSFWBack}</button>
+                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_characterListTemplate" data-var="{fullSFW}">{fullSFW}</button>
+                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_characterListTemplate" data-var="{fullSFWBack}">{fullSFWBack}</button>
+                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_characterListTemplate" data-var="{lowerSFW}">{lowerSFW}</button>
+                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_characterListTemplate" data-var="{lowerSFWBack}">{lowerSFWBack}</button>
+                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_characterListTemplate" data-var="{upperNSFW}">{upperNSFW}</button>
+                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_characterListTemplate" data-var="{upperNSFWBack}">{upperNSFWBack}</button>
+                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_characterListTemplate" data-var="{fullNSFW}">{fullNSFW}</button>
+                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_characterListTemplate" data-var="{fullNSFWBack}">{fullNSFWBack}</button>
+                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_characterListTemplate" data-var="{lowerNSFW}">{lowerNSFW}</button>
+                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_characterListTemplate" data-var="{lowerNSFWBack}">{lowerNSFWBack}</button>
+                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_characterListTemplate" data-var="{outfits}">{outfits}</button>
                 </div>
             </div>
 
@@ -680,7 +710,15 @@
                 </label>
                 <textarea id="tpl_innerOutfitTemplate" class="st-chatu8-textarea" rows="4" placeholder="设置角色专属服装的展开格式..."></textarea>
                 <div class="st-chatu8-token-display">
-                    可用占位符：<code>{outfitName}</code>, <code>{upperSFW}</code>, <code>{upperSFWBack}</code>, <code>{fullSFW}</code>, <code>{fullSFWBack}</code>, <code>{upperNSFW}</code>, <code>{upperNSFWBack}</code>, <code>{fullNSFW}</code>, <code>{fullNSFWBack}</code>
+                    <span style="font-weight: bold; margin-right: 4px;">点击变量插入：</span>
+                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_innerOutfitTemplate" data-var="{nameCN}">{nameCN}</button>
+                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_innerOutfitTemplate" data-var="{nameEN}">{nameEN}</button>
+                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_innerOutfitTemplate" data-var="{upperBody}">{upperBody}</button>
+                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_innerOutfitTemplate" data-var="{upperBodyBack}">{upperBodyBack}</button>
+                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_innerOutfitTemplate" data-var="{fullBody}">{fullBody}</button>
+                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_innerOutfitTemplate" data-var="{fullBodyBack}">{fullBodyBack}</button>
+                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_innerOutfitTemplate" data-var="{lowerBody}">{lowerBody}</button>
+                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_innerOutfitTemplate" data-var="{lowerBodyBack}">{lowerBodyBack}</button>
                 </div>
             </div>
 
@@ -691,7 +729,18 @@
                 </label>
                 <textarea id="tpl_commonCharacterListTemplate" class="st-chatu8-textarea" rows="4" placeholder="设置通用角色列表中角色的展开格式..."></textarea>
                 <div class="st-chatu8-token-display">
-                    可用占位符同角色模板；全空占位符所在行将自动智能消行清洗。
+                    <span style="font-weight: bold; margin-right: 4px;">点击变量插入：</span>
+                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_commonCharacterListTemplate" data-var="{nameCN}">{nameCN}</button>
+                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_commonCharacterListTemplate" data-var="{nameEN}">{nameEN}</button>
+                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_commonCharacterListTemplate" data-var="{traits}">{traits}</button>
+                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_commonCharacterListTemplate" data-var="{facial}">{facial}</button>
+                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_commonCharacterListTemplate" data-var="{facialBack}">{facialBack}</button>
+                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_commonCharacterListTemplate" data-var="{upperSFW}">{upperSFW}</button>
+                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_commonCharacterListTemplate" data-var="{upperSFWBack}">{upperSFWBack}</button>
+                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_commonCharacterListTemplate" data-var="{lowerSFW}">{lowerSFW}</button>
+                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_commonCharacterListTemplate" data-var="{lowerSFWBack}">{lowerSFWBack}</button>
+                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_commonCharacterListTemplate" data-var="{fullSFW}">{fullSFW}</button>
+                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_commonCharacterListTemplate" data-var="{fullSFWBack}">{fullSFWBack}</button>
                 </div>
             </div>
 
@@ -702,17 +751,29 @@
                 </label>
                 <textarea id="tpl_enableOutfitListTemplate" class="st-chatu8-textarea" rows="4" placeholder="设置通用服装列表中服装的展开格式..."></textarea>
                 <div class="st-chatu8-token-display">
-                    可用占位符同服装模板。
+                    <span style="font-weight: bold; margin-right: 4px;">点击变量插入：</span>
+                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_enableOutfitListTemplate" data-var="{nameCN}">{nameCN}</button>
+                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_enableOutfitListTemplate" data-var="{nameEN}">{nameEN}</button>
+                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_enableOutfitListTemplate" data-var="{upperBody}">{upperBody}</button>
+                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_enableOutfitListTemplate" data-var="{upperBodyBack}">{upperBodyBack}</button>
+                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_enableOutfitListTemplate" data-var="{fullBody}">{fullBody}</button>
+                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_enableOutfitListTemplate" data-var="{fullBodyBack}">{fullBodyBack}</button>
+                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_enableOutfitListTemplate" data-var="{lowerBody}">{lowerBody}</button>
+                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_enableOutfitListTemplate" data-var="{lowerBodyBack}">{lowerBodyBack}</button>
                 </div>
             </div>
         </div>
 
-        <!-- 实时预览卡片 -->
+        <!-- 实时全量预览卡片 -->
         <div class="st-chatu8-settings-section">
-            <h3>模板效果实时预览 (Live Preview)</h3>
+            <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px;">
+                <h3 style="margin: 0;">全量场景提示词合成预览 (All-in-One Live Preview)</h3>
+                <button id="injection_template_refresh_preview" class="st-chatu8-btn primary" style="font-size: 0.85em; padding: 4px 10px;">
+                    <i class="fa-solid fa-rotate"></i> 刷新预览
+                </button>
+            </div>
             <div class="st-chatu8-field-col">
-                <label for="tpl_live_preview">实时生成的提示词效果预览</label>
-                <textarea id="tpl_live_preview" class="st-chatu8-textarea" rows="6" readonly placeholder="在此预览当前模板在样例数据下的最终注入提示词..."></textarea>
+                <textarea id="tpl_live_preview" class="st-chatu8-textarea" rows="12" readonly placeholder="在此预览当前模板在包含2角色(各2服装)+2通用角色+2通用服装的模拟场景下合成出的最终提示词全貌..."></textarea>
             </div>
         </div>
     </div>

--- a/html/settings/character.html
+++ b/html/settings/character.html
@@ -641,140 +641,121 @@
 
     <!-- 提示词注入模板管理子页面 -->
     <div id="ch-sub-tab-injection-templates" class="st-chatu8-sub-tab-content" style="display: none;">
-        <!-- 预设管理卡片 -->
-        <div class="st-chatu8-settings-section">
-            <h3>提示词注入模板预设</h3>
-            <div class="st-chatu8-field">
-                <label for="injection_template_preset_id">当前方案</label>
-                <div class="st-chatu8-profile-controls">
-                    <select id="injection_template_preset_id" class="st-chatu8-select"></select>
-                    <button class="st-chatu8-icon-btn" id="injection_template_new" title="新建方案"><i class="fa-solid fa-plus"></i></button>
-                    <button class="st-chatu8-icon-btn" id="injection_template_update" title="保存方案"><i class="fa-solid fa-save"></i></button>
-                    <button class="st-chatu8-icon-btn" id="injection_template_save_as" title="另存为"><i class="fa-solid fa-file-export"></i></button>
-                    <button class="st-chatu8-icon-btn" id="injection_template_rename" title="重命名方案"><i class="fa-solid fa-pen"></i></button>
-                    <button class="st-chatu8-icon-btn" id="injection_template_reset" title="恢复系统默认方案"><i class="fa-solid fa-rotate-left"></i></button>
-                    <button class="st-chatu8-icon-btn danger" id="injection_template_delete" title="删除方案"><i class="fa-solid fa-trash"></i></button>
+        <!-- 双栏排版容器：主编辑区与侧边栏 -->
+        <div style="display: flex; gap: 16px; flex-wrap: wrap; align-items: flex-start;">
+            
+            <!-- 左侧：模板格式编辑区与实时预览 (Flex: 1) -->
+            <div style="flex: 1; min-width: 320px; display: flex; flex-direction: column; gap: 15px;">
+                <!-- 模板格式编辑卡片 -->
+                <div class="st-chatu8-settings-section">
+                    <h3><i class="fa-solid fa-sliders"></i> 模板格式配置</h3>
+
+                    <!-- 1. 角色启用列表项模板 -->
+                    <div class="st-chatu8-field-col">
+                        <label for="tpl_characterListTemplate">
+                            角色启用列表项模板 <span style="font-weight: normal; font-size: 0.85em; opacity: 0.8;">(characterListTemplate)</span>
+                        </label>
+                        <textarea id="tpl_characterListTemplate" class="st-chatu8-textarea" rows="4" placeholder="设置角色列表中每个角色的展开格式..."></textarea>
+                    </div>
+
+                    <!-- 2. 角色专属服装模板 -->
+                    <div class="st-chatu8-field-col" style="margin-top: 15px;">
+                        <label for="tpl_innerOutfitTemplate">
+                            角色专属服装模板 <span style="font-weight: normal; font-size: 0.85em; opacity: 0.8;">(innerOutfitTemplate)</span>
+                        </label>
+                        <textarea id="tpl_innerOutfitTemplate" class="st-chatu8-textarea" rows="4" placeholder="设置角色专属服装的展开格式..."></textarea>
+                    </div>
+
+                    <!-- 3. 通用角色展开模板 -->
+                    <div class="st-chatu8-field-col" style="margin-top: 15px;">
+                        <label for="tpl_commonCharacterListTemplate">
+                            通用角色展开模板 <span style="font-weight: normal; font-size: 0.85em; opacity: 0.8;">(commonCharacterListTemplate)</span>
+                        </label>
+                        <textarea id="tpl_commonCharacterListTemplate" class="st-chatu8-textarea" rows="4" placeholder="设置通用角色列表中角色的展开格式..."></textarea>
+                    </div>
+
+                    <!-- 4. 通用服装展开模板 -->
+                    <div class="st-chatu8-field-col" style="margin-top: 15px;">
+                        <label for="tpl_enableOutfitListTemplate">
+                            通用服装展开模板 <span style="font-weight: normal; font-size: 0.85em; opacity: 0.8;">(enableOutfitListTemplate)</span>
+                        </label>
+                        <textarea id="tpl_enableOutfitListTemplate" class="st-chatu8-textarea" rows="4" placeholder="设置通用服装列表中服装的展开格式..."></textarea>
+                    </div>
+                </div>
+
+                <!-- 实时全量预览卡片 -->
+                <div class="st-chatu8-settings-section">
+                    <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px;">
+                        <h3 style="margin: 0;"><i class="fa-solid fa-eye"></i> 全量场景提示词合成预览</h3>
+                        <button id="injection_template_refresh_preview" class="st-chatu8-btn primary" style="font-size: 0.85em; padding: 4px 10px;">
+                            <i class="fa-solid fa-rotate"></i> 刷新预览
+                        </button>
+                    </div>
+                    <div class="st-chatu8-field-col">
+                        <textarea id="tpl_live_preview" class="st-chatu8-textarea" rows="12" readonly placeholder="在此预览当前模板在包含2角色(各2服装)+2通用角色+2通用服装的模拟场景下合成出的最终提示词全貌..."></textarea>
+                    </div>
                 </div>
             </div>
 
-            <!-- 快捷模板方案载入 -->
-            <div class="st-chatu8-field" style="margin-top: 12px; border-top: 1px dashed rgba(255,255,255,0.1); padding-top: 10px;">
-                <label for="injection_template_quick_preset">快捷模板套件</label>
-                <div class="st-chatu8-profile-controls" style="flex: 1;">
-                    <select id="injection_template_quick_preset" class="st-chatu8-select" style="flex: 1;">
-                        <option value="default_native">原生格式模板 (插件默认拼接)</option>
-                        <option value="tavern_xml">Tavern XML 结构化模板 (推荐大模型识别)</option>
-                    </select>
-                    <button class="st-chatu8-btn" id="injection_template_apply_quick" title="将选中的快捷模板填充到下方输入框"><i class="fa-solid fa-wand-magic-sparkles"></i> 载入快捷模板</button>
+            <!-- 右侧：侧边工具栏 (Width: 300px, Sticky 吸顶) -->
+            <div style="width: 300px; min-width: 260px; position: sticky; top: 10px; display: flex; flex-direction: column; gap: 15px;">
+                <!-- 预设方案管理卡片 -->
+                <div class="st-chatu8-settings-section">
+                    <h3><i class="fa-solid fa-folder-tree"></i> 方案管理</h3>
+                    <div class="st-chatu8-field-col">
+                        <label for="injection_template_preset_id">当前方案</label>
+                        <select id="injection_template_preset_id" class="st-chatu8-select" style="margin-bottom: 8px;"></select>
+                        <div class="st-chatu8-profile-controls" style="justify-content: flex-start; flex-wrap: wrap;">
+                            <button class="st-chatu8-icon-btn" id="injection_template_new" title="新建方案"><i class="fa-solid fa-plus"></i></button>
+                            <button class="st-chatu8-icon-btn" id="injection_template_update" title="保存方案"><i class="fa-solid fa-save"></i></button>
+                            <button class="st-chatu8-icon-btn" id="injection_template_save_as" title="另存为"><i class="fa-solid fa-file-export"></i></button>
+                            <button class="st-chatu8-icon-btn" id="injection_template_rename" title="重命名方案"><i class="fa-solid fa-pen"></i></button>
+                            <button class="st-chatu8-icon-btn" id="injection_template_reset" title="恢复系统默认方案"><i class="fa-solid fa-rotate-left"></i></button>
+                            <button class="st-chatu8-icon-btn danger" id="injection_template_delete" title="删除方案"><i class="fa-solid fa-trash"></i></button>
+                        </div>
+                    </div>
                 </div>
-            </div>
-        </div>
 
-        <!-- 模板配置卡片 -->
-        <div class="st-chatu8-settings-section">
-            <h3>模板格式配置</h3>
-
-            <!-- 1. 角色启用列表项模板 -->
-            <div class="st-chatu8-field-col">
-                <label for="tpl_characterListTemplate">
-                    角色启用列表项模板 <span style="font-weight: normal; font-size: 0.85em; opacity: 0.8;">(characterListTemplate)</span>
-                </label>
-                <textarea id="tpl_characterListTemplate" class="st-chatu8-textarea" rows="4" placeholder="设置角色列表中每个角色的展开格式..."></textarea>
-                <div class="st-chatu8-token-display">
-                    <span style="font-weight: bold; margin-right: 4px;">点击变量插入：</span>
-                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_characterListTemplate" data-var="{nameCN}">{nameCN}</button>
-                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_characterListTemplate" data-var="{nameEN}">{nameEN}</button>
-                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_characterListTemplate" data-var="{traits}">{traits}</button>
-                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_characterListTemplate" data-var="{facial}">{facial}</button>
-                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_characterListTemplate" data-var="{facialBack}">{facialBack}</button>
-                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_characterListTemplate" data-var="{upperSFW}">{upperSFW}</button>
-                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_characterListTemplate" data-var="{upperSFWBack}">{upperSFWBack}</button>
-                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_characterListTemplate" data-var="{fullSFW}">{fullSFW}</button>
-                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_characterListTemplate" data-var="{fullSFWBack}">{fullSFWBack}</button>
-                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_characterListTemplate" data-var="{lowerSFW}">{lowerSFW}</button>
-                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_characterListTemplate" data-var="{lowerSFWBack}">{lowerSFWBack}</button>
-                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_characterListTemplate" data-var="{upperNSFW}">{upperNSFW}</button>
-                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_characterListTemplate" data-var="{upperNSFWBack}">{upperNSFWBack}</button>
-                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_characterListTemplate" data-var="{fullNSFW}">{fullNSFW}</button>
-                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_characterListTemplate" data-var="{fullNSFWBack}">{fullNSFWBack}</button>
-                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_characterListTemplate" data-var="{lowerNSFW}">{lowerNSFW}</button>
-                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_characterListTemplate" data-var="{lowerNSFWBack}">{lowerNSFWBack}</button>
-                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_characterListTemplate" data-var="{outfits}">{outfits}</button>
-                </div>
-            </div>
-
-            <!-- 2. 角色专属服装模板 -->
-            <div class="st-chatu8-field-col" style="margin-top: 15px;">
-                <label for="tpl_innerOutfitTemplate">
-                    角色专属服装模板 <span style="font-weight: normal; font-size: 0.85em; opacity: 0.8;">(innerOutfitTemplate)</span>
-                </label>
-                <textarea id="tpl_innerOutfitTemplate" class="st-chatu8-textarea" rows="4" placeholder="设置角色专属服装的展开格式..."></textarea>
-                <div class="st-chatu8-token-display">
-                    <span style="font-weight: bold; margin-right: 4px;">点击变量插入：</span>
-                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_innerOutfitTemplate" data-var="{nameCN}">{nameCN}</button>
-                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_innerOutfitTemplate" data-var="{nameEN}">{nameEN}</button>
-                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_innerOutfitTemplate" data-var="{upperBody}">{upperBody}</button>
-                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_innerOutfitTemplate" data-var="{upperBodyBack}">{upperBodyBack}</button>
-                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_innerOutfitTemplate" data-var="{fullBody}">{fullBody}</button>
-                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_innerOutfitTemplate" data-var="{fullBodyBack}">{fullBodyBack}</button>
-                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_innerOutfitTemplate" data-var="{lowerBody}">{lowerBody}</button>
-                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_innerOutfitTemplate" data-var="{lowerBodyBack}">{lowerBodyBack}</button>
+                <!-- 快捷变量工具箱卡片 -->
+                <div class="st-chatu8-settings-section">
+                    <h3><i class="fa-solid fa-code"></i> 快捷插入占位符变量</h3>
+                    <div class="st-chatu8-field-col">
+                        <label for="injection_template_var_select">选择变量</label>
+                        <select id="injection_template_var_select" class="st-chatu8-select">
+                            <option value="">-- 选择要插入的变量 --</option>
+                            <optgroup label="角色模板变量">
+                                <option value="{nameCN}">{nameCN} - 角色中文名称</option>
+                                <option value="{nameEN}">{nameEN} - 角色英文标识符</option>
+                                <option value="{traits}">{traits} - 角色特征(Tag/来源/年龄)</option>
+                                <option value="{facial}">{facial} - 五官外貌(正面面部特征)</option>
+                                <option value="{facialBack}">{facialBack} - 五官外貌(背面特征)</option>
+                                <option value="{upperSFW}">{upperSFW} - 上半身SFW(裸体姿态特征)</option>
+                                <option value="{upperSFWBack}">{upperSFWBack} - 上半身SFW(背面线条)</option>
+                                <option value="{lowerSFW}">{lowerSFW} - 下半身SFW(腿部轮廓比例)</option>
+                                <option value="{lowerSFWBack}">{lowerSFWBack} - 下半身SFW(臀腿背面)</option>
+                                <option value="{upperNSFW}">{upperNSFW} - 上半身NSFW(解剖细节)</option>
+                                <option value="{upperNSFWBack}">{upperNSFWBack} - 上半身NSFW(背面解剖)</option>
+                                <option value="{lowerNSFW}">{lowerNSFW} - 下半身NSFW(解剖主标签)</option>
+                                <option value="{lowerNSFWBack}">{lowerNSFWBack} - 下半身NSFW(写实解剖)</option>
+                                <option value="{negative}">{negative} - 角色负面提示词</option>
+                                <option value="{outfits}">{outfits} - 角色专属服装展开点</option>
+                            </optgroup>
+                            <optgroup label="服装模板变量">
+                                <option value="{upperBody}">{upperBody} - 上半身服装款式/材质</option>
+                                <option value="{upperBodyBack}">{upperBodyBack} - 上半身服装背面结构</option>
+                                <option value="{fullBody}">{fullBody} - 下半身服装/裙裤配饰</option>
+                                <option value="{fullBodyBack}">{fullBodyBack} - 下半身服装背面剪裁</option>
+                                <option value="{lowerBody}">{lowerBody} - 下半身服装 (别名)</option>
+                                <option value="{lowerBodyBack}">{lowerBodyBack} - 下半身服装背面 (别名)</option>
+                            </optgroup>
+                        </select>
+                        <button class="st-chatu8-btn primary" id="injection_template_insert_var_btn" type="button" style="margin-top: 10px; width: 100%;">
+                            <i class="fa-solid fa-plus-circle"></i> 插入到光标处
+                        </button>
+                    </div>
                 </div>
             </div>
 
-            <!-- 3. 通用角色展开模板 -->
-            <div class="st-chatu8-field-col" style="margin-top: 15px;">
-                <label for="tpl_commonCharacterListTemplate">
-                    通用角色展开模板 <span style="font-weight: normal; font-size: 0.85em; opacity: 0.8;">(commonCharacterListTemplate)</span>
-                </label>
-                <textarea id="tpl_commonCharacterListTemplate" class="st-chatu8-textarea" rows="4" placeholder="设置通用角色列表中角色的展开格式..."></textarea>
-                <div class="st-chatu8-token-display">
-                    <span style="font-weight: bold; margin-right: 4px;">点击变量插入：</span>
-                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_commonCharacterListTemplate" data-var="{nameCN}">{nameCN}</button>
-                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_commonCharacterListTemplate" data-var="{nameEN}">{nameEN}</button>
-                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_commonCharacterListTemplate" data-var="{traits}">{traits}</button>
-                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_commonCharacterListTemplate" data-var="{facial}">{facial}</button>
-                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_commonCharacterListTemplate" data-var="{facialBack}">{facialBack}</button>
-                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_commonCharacterListTemplate" data-var="{upperSFW}">{upperSFW}</button>
-                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_commonCharacterListTemplate" data-var="{upperSFWBack}">{upperSFWBack}</button>
-                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_commonCharacterListTemplate" data-var="{lowerSFW}">{lowerSFW}</button>
-                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_commonCharacterListTemplate" data-var="{lowerSFWBack}">{lowerSFWBack}</button>
-                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_commonCharacterListTemplate" data-var="{fullSFW}">{fullSFW}</button>
-                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_commonCharacterListTemplate" data-var="{fullSFWBack}">{fullSFWBack}</button>
-                </div>
-            </div>
-
-            <!-- 4. 通用服装展开模板 -->
-            <div class="st-chatu8-field-col" style="margin-top: 15px;">
-                <label for="tpl_enableOutfitListTemplate">
-                    通用服装展开模板 <span style="font-weight: normal; font-size: 0.85em; opacity: 0.8;">(enableOutfitListTemplate)</span>
-                </label>
-                <textarea id="tpl_enableOutfitListTemplate" class="st-chatu8-textarea" rows="4" placeholder="设置通用服装列表中服装的展开格式..."></textarea>
-                <div class="st-chatu8-token-display">
-                    <span style="font-weight: bold; margin-right: 4px;">点击变量插入：</span>
-                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_enableOutfitListTemplate" data-var="{nameCN}">{nameCN}</button>
-                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_enableOutfitListTemplate" data-var="{nameEN}">{nameEN}</button>
-                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_enableOutfitListTemplate" data-var="{upperBody}">{upperBody}</button>
-                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_enableOutfitListTemplate" data-var="{upperBodyBack}">{upperBodyBack}</button>
-                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_enableOutfitListTemplate" data-var="{fullBody}">{fullBody}</button>
-                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_enableOutfitListTemplate" data-var="{fullBodyBack}">{fullBodyBack}</button>
-                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_enableOutfitListTemplate" data-var="{lowerBody}">{lowerBody}</button>
-                    <button type="button" class="st-chatu8-var-btn" data-target="tpl_enableOutfitListTemplate" data-var="{lowerBodyBack}">{lowerBodyBack}</button>
-                </div>
-            </div>
-        </div>
-
-        <!-- 实时全量预览卡片 -->
-        <div class="st-chatu8-settings-section">
-            <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px;">
-                <h3 style="margin: 0;">全量场景提示词合成预览 (All-in-One Live Preview)</h3>
-                <button id="injection_template_refresh_preview" class="st-chatu8-btn primary" style="font-size: 0.85em; padding: 4px 10px;">
-                    <i class="fa-solid fa-rotate"></i> 刷新预览
-                </button>
-            </div>
-            <div class="st-chatu8-field-col">
-                <textarea id="tpl_live_preview" class="st-chatu8-textarea" rows="12" readonly placeholder="在此预览当前模板在包含2角色(各2服装)+2通用角色+2通用服装的模拟场景下合成出的最终提示词全貌..."></textarea>
-            </div>
         </div>
     </div>
 </div>

--- a/html/settings/character.html
+++ b/html/settings/character.html
@@ -7,6 +7,7 @@
         <a href="#" class="st-chatu8-sub-nav-link" data-sub-tab="ch-sub-tab-outfit-enable">启用通用服装列表</a>
         <a href="#" class="st-chatu8-sub-nav-link" data-sub-tab="ch-sub-tab-character-common">启用通用角色列表</a>
         <a href="#" class="st-chatu8-sub-nav-link" data-sub-tab="ch-sub-tab-banana-character">Banana角色管理</a>
+        <a href="#" class="st-chatu8-sub-nav-link" data-sub-tab="ch-sub-tab-injection-templates">提示词注入模板</a>
     </div>
 
     <!-- 角色设定子页面 -->
@@ -634,6 +635,84 @@
                         </div>
                     </div>
                 </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- 提示词注入模板管理子页面 -->
+    <div id="ch-sub-tab-injection-templates" class="st-chatu8-sub-tab-content" style="display: none;">
+        <!-- 预设管理卡片 -->
+        <div class="st-chatu8-settings-section">
+            <h3>提示词注入模板预设</h3>
+            <div class="st-chatu8-field">
+                <label for="injection_template_preset_id">当前方案</label>
+                <div class="st-chatu8-profile-controls">
+                    <select id="injection_template_preset_id" class="st-chatu8-select"></select>
+                    <button class="st-chatu8-icon-btn" id="injection_template_new" title="新建方案"><i class="fa-solid fa-plus"></i></button>
+                    <button class="st-chatu8-icon-btn" id="injection_template_update" title="保存方案"><i class="fa-solid fa-save"></i></button>
+                    <button class="st-chatu8-icon-btn" id="injection_template_save_as" title="另存为"><i class="fa-solid fa-file-export"></i></button>
+                    <button class="st-chatu8-icon-btn" id="injection_template_rename" title="重命名方案"><i class="fa-solid fa-pen"></i></button>
+                    <button class="st-chatu8-icon-btn" id="injection_template_reset" title="恢复系统默认方案"><i class="fa-solid fa-rotate-left"></i></button>
+                    <button class="st-chatu8-icon-btn danger" id="injection_template_delete" title="删除方案"><i class="fa-solid fa-trash"></i></button>
+                </div>
+            </div>
+        </div>
+
+        <!-- 模板配置卡片 -->
+        <div class="st-chatu8-settings-section">
+            <h3>模板格式配置</h3>
+
+            <!-- 1. 角色启用列表项模板 -->
+            <div class="st-chatu8-field-col">
+                <label for="tpl_characterListTemplate">
+                    角色启用列表项模板 <span style="font-weight: normal; font-size: 0.85em; opacity: 0.8;">(characterListTemplate)</span>
+                </label>
+                <textarea id="tpl_characterListTemplate" class="st-chatu8-textarea" rows="4" placeholder="设置角色列表中每个角色的展开格式..."></textarea>
+                <div class="st-chatu8-token-display">
+                    可用占位符：<code>{nameCN}</code>, <code>{nameEN}</code>, <code>{traits}</code>, <code>{facial}</code>, <code>{facialBack}</code>, <code>{upperSFW}</code>, <code>{upperSFWBack}</code>, <code>{fullSFW}</code>, <code>{fullSFWBack}</code>, <code>{upperNSFW}</code>, <code>{upperNSFWBack}</code>, <code>{fullNSFW}</code>, <code>{fullNSFWBack}</code>, <code>{outfit}</code>
+                </div>
+            </div>
+
+            <!-- 2. 角色专属服装模板 -->
+            <div class="st-chatu8-field-col" style="margin-top: 15px;">
+                <label for="tpl_innerOutfitTemplate">
+                    角色专属服装模板 <span style="font-weight: normal; font-size: 0.85em; opacity: 0.8;">(innerOutfitTemplate)</span>
+                </label>
+                <textarea id="tpl_innerOutfitTemplate" class="st-chatu8-textarea" rows="4" placeholder="设置角色专属服装的展开格式..."></textarea>
+                <div class="st-chatu8-token-display">
+                    可用占位符：<code>{outfitName}</code>, <code>{upperSFW}</code>, <code>{upperSFWBack}</code>, <code>{fullSFW}</code>, <code>{fullSFWBack}</code>, <code>{upperNSFW}</code>, <code>{upperNSFWBack}</code>, <code>{fullNSFW}</code>, <code>{fullNSFWBack}</code>
+                </div>
+            </div>
+
+            <!-- 3. 通用角色展开模板 -->
+            <div class="st-chatu8-field-col" style="margin-top: 15px;">
+                <label for="tpl_commonCharacterListTemplate">
+                    通用角色展开模板 <span style="font-weight: normal; font-size: 0.85em; opacity: 0.8;">(commonCharacterListTemplate)</span>
+                </label>
+                <textarea id="tpl_commonCharacterListTemplate" class="st-chatu8-textarea" rows="4" placeholder="设置通用角色列表中角色的展开格式..."></textarea>
+                <div class="st-chatu8-token-display">
+                    可用占位符同角色模板；全空占位符所在行将自动智能消行清洗。
+                </div>
+            </div>
+
+            <!-- 4. 通用服装展开模板 -->
+            <div class="st-chatu8-field-col" style="margin-top: 15px;">
+                <label for="tpl_enableOutfitListTemplate">
+                    通用服装展开模板 <span style="font-weight: normal; font-size: 0.85em; opacity: 0.8;">(enableOutfitListTemplate)</span>
+                </label>
+                <textarea id="tpl_enableOutfitListTemplate" class="st-chatu8-textarea" rows="4" placeholder="设置通用服装列表中服装的展开格式..."></textarea>
+                <div class="st-chatu8-token-display">
+                    可用占位符同服装模板。
+                </div>
+            </div>
+        </div>
+
+        <!-- 实时预览卡片 -->
+        <div class="st-chatu8-settings-section">
+            <h3>模板效果实时预览 (Live Preview)</h3>
+            <div class="st-chatu8-field-col">
+                <label for="tpl_live_preview">实时生成的提示词效果预览</label>
+                <textarea id="tpl_live_preview" class="st-chatu8-textarea" rows="6" readonly style="background: var(--SmartThemeBlurTintColor); cursor: default; font-family: monospace; font-size: 0.9em;"></textarea>
             </div>
         </div>
     </div>

--- a/html/settings/character.html
+++ b/html/settings/character.html
@@ -712,7 +712,7 @@
             <h3>模板效果实时预览 (Live Preview)</h3>
             <div class="st-chatu8-field-col">
                 <label for="tpl_live_preview">实时生成的提示词效果预览</label>
-                <textarea id="tpl_live_preview" class="st-chatu8-textarea" rows="6" readonly style="background: var(--SmartThemeBlurTintColor); cursor: default; font-family: monospace; font-size: 0.9em;"></textarea>
+                <textarea id="tpl_live_preview" class="st-chatu8-textarea" rows="6" readonly placeholder="在此预览当前模板在样例数据下的最终注入提示词..."></textarea>
             </div>
         </div>
     </div>

--- a/index.js
+++ b/index.js
@@ -22118,6 +22118,14 @@ function isCharacterTriggered(character, triggerText) {
       }
     }
   }
+  if (character.triggers) {
+    const customTriggers = character.triggers.split("|").map((name) => normalizeTriggerText(name)).filter((name) => name);
+    for (const name of customTriggers) {
+      if (normalizedTrigger.includes(name)) {
+        return true;
+      }
+    }
+  }
   return false;
 }
 function getTriggeredCharacterName(character, triggerText) {
@@ -22392,10 +22400,25 @@ async function getCommonCharacterImages() {
   }
   return collectedImages;
 }
+function getChatTriggerTextForWorldBook() {
+  try {
+    const context = (typeof getContext16 === "function" ? getContext16() : null) || (typeof getContext === "function" ? getContext() : null) || (typeof SillyTavern !== "undefined" ? SillyTavern.getContext() : null);
+    if (!context || !Array.isArray(context.chat) || context.chat.length === 0) {
+      return null;
+    }
+    const recentMsgs = context.chat.slice(-20);
+    const textParts = recentMsgs.map((m) => m.mes || m.text || "").filter(Boolean);
+    return textParts.join("\n");
+  } catch (e) {
+    return null;
+  }
+}
+
 function setupWorldBookEventListener() {
   eventSource11.on(event_types2.WORLDINFO_ENTRIES_LOADED, (data) => {
     const settings3 = extension_settings20[extensionName];
-    const characterListText = generateCharacterListText();
+    const triggerText = getChatTriggerTextForWorldBook();
+    const characterListText = generateCharacterListText(triggerText);
     const outfitEnableListText = generateOutfitEnableListText();
     const commonCharacterListText = generateCommonCharacterListText();
     console.log("[WorldBook] Character list text:", characterListText);
@@ -28179,35 +28202,56 @@ function getActiveInjectionTemplates(settingsObj) {
 function applyInjectionTemplate(templateStr, dataMap) {
   if (!templateStr || typeof templateStr !== "string") return "";
 
-  let replaced = templateStr;
-  for (const [key, val] of Object.entries(dataMap || {})) {
-    const valStr = val != null ? String(val) : "";
-    const regex = new RegExp(`\\{\\{?${key}\\}?\\}`, "g");
-    replaced = replaced.replace(regex, valStr);
-  }
-
-  const lines = replaced.split(/\r?\n/);
-  const cleanedLines = [];
+  const lines = templateStr.split(/\r?\n/);
+  const resultLines = [];
 
   for (let i = 0; i < lines.length; i++) {
     const rawLine = lines[i];
-    const trimmedLine = rawLine.trim();
+    const placeholderMatches = [...rawLine.matchAll(/\{\{?([a-zA-Z0-9_]+)\}?\}/g)];
 
-    const rawTemplateLine = (templateStr.split(/\r?\n/)[i] || "");
-    const hadPlaceholder = /\{\{?[a-zA-Z0-9_]+\}?\}/.test(rawTemplateLine);
-
-    if (hadPlaceholder) {
-      const textOnly = trimmedLine.replace(/[\s:：,，\-–—]/g, "");
-      if (!textOnly) {
+    if (placeholderMatches.length > 0) {
+      let allPlaceholdersNull = true;
+      for (const match of placeholderMatches) {
+        const key = match[1];
+        const val = dataMap?.[key];
+        if (val !== undefined && val !== null && String(val).trim() !== "") {
+          allPlaceholdersNull = false;
+          break;
+        }
+      }
+      if (allPlaceholdersNull) {
         continue;
       }
     }
-    cleanedLines.push(rawLine);
+
+    let replaced = rawLine;
+    if (placeholderMatches.length > 0) {
+      for (const match of placeholderMatches) {
+        const key = match[1];
+        const val = dataMap?.[key];
+        const valStr = (val !== undefined && val !== null && String(val).trim() !== "") ? String(val) : "null";
+        const regex = new RegExp(`\\{\\{?${key}\\}?\\}`, "g");
+        replaced = replaced.replace(regex, valStr);
+      }
+    }
+
+    resultLines.push(replaced);
   }
 
-  let result = cleanedLines.join("\n").replace(/\n{3,}/g, "\n\n").trim();
-  result = result.replace(/,\s*$/g, "");
-  return result;
+  const cleaned = [];
+  for (let i = 0; i < resultLines.length; i++) {
+    const line = resultLines[i];
+    const nextLine = resultLines[i + 1];
+    const trimmed = line.trim();
+
+    if ((trimmed === "服装列表：" || trimmed === "服装列表:" || trimmed === "[Outfits]" || trimmed === "服装列表" || trimmed === "- 服装列表:") &&
+        (!nextLine || nextLine.startsWith("中文名称：") || nextLine.startsWith("### ") || nextLine.startsWith("<character") || nextLine.startsWith("<common_"))) {
+      continue;
+    }
+    cleaned.push(line);
+  }
+
+  return cleaned.join("\n").replace(/\n{3,}/g, "\n\n").trim();
 }
 
 function renderInjectionTemplateLivePreview(container) {

--- a/index.js
+++ b/index.js
@@ -22148,6 +22148,14 @@ function getTriggeredCharacterName(character, triggerText) {
       }
     }
   }
+  if (character.triggers) {
+    const customTriggers = character.triggers.split("|").map((name) => name.trim()).filter((name) => name);
+    for (const name of customTriggers) {
+      if (normalizedTrigger.includes(normalizeTriggerText(name))) {
+        return name;
+      }
+    }
+  }
   return null;
 }
 function inspectCharacterListTrigger(triggerText) {

--- a/index.js
+++ b/index.js
@@ -28075,6 +28075,7 @@ function getCharacterPromptData(character, settingsObj) {
     fullNSFWBack: character.fullBodyNSFWBack || "",
     lowerNSFW: character.fullBodyNSFW || character.lowerBodyNSFW || "",
     lowerNSFWBack: character.fullBodyNSFWBack || character.lowerBodyNSFWBack || "",
+    negative: character.negative || "",
     outfit: outfitsJoined,
     outfits: outfitsJoined
   };
@@ -28111,35 +28112,52 @@ function getOutfitPromptData(outfit) {
   };
 }
 
-const QUICK_INJECTION_TEMPLATES = {
-  default_native: {
-    characterListTemplate: `{nameCN} ({nameEN})\n角色特征:\n{traits}\n五官外貌:\n{facial}\n{facialBack}\nSFW:\n{upperSFW}\n{upperSFWBack}\n{fullSFW}\n{fullSFWBack}\nNSFW:\n{upperNSFW}\n{upperNSFWBack}\n{fullNSFW}\n{fullNSFWBack}\n{outfit}`,
-    innerOutfitTemplate: `{outfitName}\nSFW:\n{upperSFW}\n{upperSFWBack}\n{fullSFW}\n{fullSFWBack}\nNSFW:\n{upperNSFW}\n{upperNSFWBack}\n{fullNSFW}\n{fullNSFWBack}`,
-    commonCharacterListTemplate: `{nameCN} ({nameEN})\n角色特征:\n{traits}\n五官外貌:\n{facial}\n{facialBack}\nSFW:\n{upperSFW}\n{upperSFWBack}\n{fullSFW}\n{fullSFWBack}\nNSFW:\n{upperNSFW}\n{upperNSFWBack}\n{fullNSFW}\n{fullNSFWBack}`,
-    enableOutfitListTemplate: `{outfitName}\nSFW:\n{upperSFW}\n{upperSFWBack}\n{fullSFW}\n{fullSFWBack}\nNSFW:\n{upperNSFW}\n{upperNSFWBack}\n{fullNSFW}\n{fullNSFWBack}`
+const SYSTEM_PRESET_IDS = ["默认方案", "Tavern XML 格式", "Markdown 极简卡片"];
+
+const SYSTEM_INJECTION_TEMPLATES = {
+  "默认方案": {
+    characterListTemplate: `中文名称：{nameCN}\n英文名称：{nameEN}\n角色特征：{traits}\n五官外貌（正面）：{facial}\n五官外貌（背面）：{facialBack}\n上半身SFW（正面）：{upperSFW}\n上半身SFW（背面）：{upperSFWBack}\n下半身SFW（正面）：{lowerSFW}\n下半身SFW（背面）：{lowerSFWBack}\n上半身NSFW（正面）：{upperNSFW}\n上半身NSFW（背面）：{upperNSFWBack}\n下半身NSFW（正面）：{lowerNSFW}\n下半身NSFW（背面）：{lowerNSFWBack}\n服装列表：\n{outfits}`,
+    innerOutfitTemplate: `  中文名称：{nameCN}\n  英文名称：{nameEN}\n  上半身（正面）：{upperBody}\n  上半身（背面）：{upperBodyBack}\n  下半身（正面）：{fullBody}\n  下半身（背面）：{fullBodyBack}`,
+    commonCharacterListTemplate: `中文名称：{nameCN}\n英文名称：{nameEN}\n角色特征：{traits}\n五官外貌（正面）：{facial}\n五官外貌（背面）：{facialBack}\n上半身SFW（正面）：{upperSFW}\n上半身SFW（背面）：{upperSFWBack}\n下半身SFW（正面）：{lowerSFW}\n下半身SFW（背面）：{lowerSFWBack}\n上半身NSFW（正面）：{upperNSFW}\n上半身NSFW（背面）：{upperNSFWBack}\n下半身NSFW（正面）：{lowerNSFW}\n下半身NSFW（背面）：{lowerNSFWBack}`,
+    enableOutfitListTemplate: `中文名称：{nameCN}\n英文名称：{nameEN}\n上半身（正面）：{upperBody}\n上半身（背面）：{upperBodyBack}\n下半身（正面）：{fullBody}\n下半身（背面）：{fullBodyBack}`
   },
-  tavern_xml: {
-    characterListTemplate: `<character name="{nameCN}" english_name="{nameEN}">\n  <traits>{traits}</traits>\n  <appearance>{facial} {facialBack}</appearance>\n  <clothing>{upperSFW}, {fullSFW}</clothing>\n  <outfits>\n{outfit}\n  </outfits>\n</character>`,
-    innerOutfitTemplate: `  <outfit name="{outfitName}">\n    <upper>{upperBody}</upper>\n    <lower>{fullBody}</lower>\n  </outfit>`,
-    commonCharacterListTemplate: `<common_character name="{nameCN}" english_name="{nameEN}">\n  <traits>{traits}</traits>\n  <appearance>{facial}</appearance>\n  <clothing>{upperSFW}, {fullSFW}</clothing>\n</common_character>`,
-    enableOutfitListTemplate: `<common_outfit name="{outfitName}">\n  <upper>{upperBody}</upper>\n  <lower>{fullBody}</lower>\n</common_outfit>`
+  "Tavern XML 格式": {
+    characterListTemplate: `<character name="{nameCN}" english_name="{nameEN}">\n  <traits>{traits}</traits>\n  <appearance>Front: {facial} | Back: {facialBack}</appearance>\n  <body_sfw>Upper: {upperSFW} ({upperSFWBack}) | Lower: {lowerSFW} ({lowerSFWBack})</body_sfw>\n  <body_nsfw>Upper: {upperNSFW} ({upperNSFWBack}) | Lower: {lowerNSFW} ({lowerNSFWBack})</body_nsfw>\n  <outfits>\n{outfits}\n  </outfits>\n</character>`,
+    innerOutfitTemplate: `  <outfit name="{nameCN}" english_name="{nameEN}">\n    <upper>Front: {upperBody} | Back: {upperBodyBack}</upper>\n    <lower>Front: {fullBody} | Back: {fullBodyBack}</lower>\n  </outfit>`,
+    commonCharacterListTemplate: `<common_character name="{nameCN}" english_name="{nameEN}">\n  <traits>{traits}</traits>\n  <appearance>Front: {facial} | Back: {facialBack}</appearance>\n  <body_sfw>Upper: {upperSFW} | Lower: {lowerSFW}</body_sfw>\n</common_character>`,
+    enableOutfitListTemplate: `<common_outfit name="{nameCN}" english_name="{nameEN}">\n  <upper>Front: {upperBody} | Back: {upperBodyBack}</upper>\n  <lower>Front: {fullBody} | Back: {fullBodyBack}</lower>\n</common_outfit>`
+  },
+  "Markdown 极简卡片": {
+    characterListTemplate: `### 角色：{nameCN} ({nameEN})\n- **特征**: {traits}\n- **面部**: {facial} (背面: {facialBack})\n- **体型SFW**: 上身({upperSFW} / {upperSFWBack}), 下身({lowerSFW} / {lowerSFWBack})\n- **解剖NSFW**: 上身({upperNSFW} / {upperNSFWBack}), 下身({lowerNSFW} / {lowerNSFWBack})\n- **服装**:\n{outfits}`,
+    innerOutfitTemplate: `  * 服装：{nameCN} ({nameEN}) -> 上身: {upperBody} ({upperBodyBack}) | 下身: {fullBody} ({fullBodyBack})`,
+    commonCharacterListTemplate: `### 通用角色：{nameCN} ({nameEN})\n- **特征**: {traits}\n- **面部**: {facial}\n- **体型**: {upperSFW}, {lowerSFW}`,
+    enableOutfitListTemplate: `### 通用服装：{nameCN} ({nameEN})\n- **上身**: {upperBody} ({upperBodyBack})\n- **下身**: {fullBody} ({fullBodyBack})`
   }
 };
 
 function getSystemDefaultInjectionTemplates() {
-  return QUICK_INJECTION_TEMPLATES.default_native;
+  return SYSTEM_INJECTION_TEMPLATES["默认方案"];
 }
 
 function ensureInjectionTemplatesInit(settingsObj) {
   const target = settingsObj || getCharacterSettingsRoot();
   if (!target) return;
-  if (!target.injectionTemplates || !target.injectionTemplates.presets) {
+  if (!target.injectionTemplates) {
     target.injectionTemplates = {
-      presets: {
-        "默认方案": getSystemDefaultInjectionTemplates()
-      },
+      presets: {},
       currentPresetId: "默认方案"
     };
+  }
+  if (!target.injectionTemplates.presets) {
+    target.injectionTemplates.presets = {};
+  }
+  for (const [id, sysTpl] of Object.entries(SYSTEM_INJECTION_TEMPLATES)) {
+    if (!target.injectionTemplates.presets[id]) {
+      target.injectionTemplates.presets[id] = { ...sysTpl };
+    }
+  }
+  if (!target.injectionTemplates.currentPresetId || !target.injectionTemplates.presets[target.injectionTemplates.currentPresetId]) {
+    target.injectionTemplates.currentPresetId = "默认方案";
   }
 }
 
@@ -28341,43 +28359,53 @@ function setupInjectionTemplateControls(container) {
     }
   });
 
+  let $lastActiveTextarea = container.find("#tpl_characterListTemplate");
+
+  container.find("#tpl_characterListTemplate, #tpl_innerOutfitTemplate, #tpl_commonCharacterListTemplate, #tpl_enableOutfitListTemplate")
+    .off("focus click").on("focus click", function () {
+      $lastActiveTextarea = $(this);
+    });
+
+  container.find("#injection_template_insert_var_btn").off("click").on("click", function (e) {
+    e.preventDefault();
+    const varTag = container.find("#injection_template_var_select").val();
+    if (!varTag) {
+      if (typeof toastr !== "undefined") toastr.warning("请先选择要插入的占位符变量！");
+      return;
+    }
+
+    if (!$lastActiveTextarea || $lastActiveTextarea.length === 0) {
+      $lastActiveTextarea = container.find("#tpl_characterListTemplate");
+    }
+
+    const el = $lastActiveTextarea[0];
+    if (!el) return;
+
+    const start = el.selectionStart || 0;
+    const end = el.selectionEnd || 0;
+    const val = $lastActiveTextarea.val() || "";
+
+    const newVal = val.substring(0, start) + varTag + val.substring(end);
+    $lastActiveTextarea.val(newVal);
+
+    el.focus();
+    el.selectionStart = el.selectionEnd = start + varTag.length;
+
+    $lastActiveTextarea.trigger("input");
+
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(varTag).catch(() => {});
+    }
+
+    if (typeof toastr !== "undefined") {
+      toastr.info(`已插入变量 ${varTag}`);
+    }
+  });
+
   container.find("#injection_template_refresh_preview").off("click").on("click", function () {
     renderInjectionTemplateLivePreview(container);
     if (typeof toastr !== "undefined") {
       toastr.success("全量实时预览已刷新！");
-    }
-  });
-
-  container.find("#injection_template_apply_quick").off("click").on("click", function () {
-    const quickKey = container.find("#injection_template_quick_preset").val();
-    const quickTpls = QUICK_INJECTION_TEMPLATES[quickKey];
-    if (!quickTpls) {
-      if (typeof toastr !== "undefined") toastr.error("未找到对应的快捷模板方案！");
-      return;
-    }
-
-    container.find("#tpl_characterListTemplate").val(quickTpls.characterListTemplate || "");
-    container.find("#tpl_innerOutfitTemplate").val(quickTpls.innerOutfitTemplate || "");
-    container.find("#tpl_commonCharacterListTemplate").val(quickTpls.commonCharacterListTemplate || "");
-    container.find("#tpl_enableOutfitListTemplate").val(quickTpls.enableOutfitListTemplate || "");
-
-    renderInjectionTemplateLivePreview(container);
-
-    const targetSettings = getCharacterSettingsRoot();
-    if (targetSettings) {
-      ensureInjectionTemplatesInit(targetSettings);
-      const currentId = targetSettings.injectionTemplates.currentPresetId || "默认方案";
-      targetSettings.injectionTemplates.presets[currentId] = {
-        characterListTemplate: container.find("#tpl_characterListTemplate").val(),
-        innerOutfitTemplate: container.find("#tpl_innerOutfitTemplate").val(),
-        commonCharacterListTemplate: container.find("#tpl_commonCharacterListTemplate").val(),
-        enableOutfitListTemplate: container.find("#tpl_enableOutfitListTemplate").val()
-      };
-      saveSettingsDebounced();
-    }
-
-    if (typeof toastr !== "undefined") {
-      toastr.success("已载入快捷模板并自动同步至当前方案！");
     }
   });
 
@@ -28458,14 +28486,19 @@ function setupInjectionTemplateControls(container) {
     ensureInjectionTemplatesInit(targetSettings);
 
     const oldId = targetSettings.injectionTemplates.currentPresetId || "默认方案";
-    if (oldId === "默认方案") {
-      toastr.warning("默认方案不可重命名！");
+    if (SYSTEM_PRESET_IDS.includes(oldId)) {
+      toastr.warning(`系统预置方案 "${oldId}" 不可重命名！`);
       return;
     }
 
     const newName = await callGenericPopup(`重命名方案 "${oldId}" 为：`, POPUP_TYPE.INPUT, oldId);
     if (!newName || !newName.trim() || newName.trim() === oldId) return;
     const newId = newName.trim();
+
+    if (targetSettings.injectionTemplates.presets[newId]) {
+      toastr.error(`方案 "${newId}" 已存在！`);
+      return;
+    }
 
     targetSettings.injectionTemplates.presets[newId] = targetSettings.injectionTemplates.presets[oldId];
     delete targetSettings.injectionTemplates.presets[oldId];
@@ -28476,17 +28509,19 @@ function setupInjectionTemplateControls(container) {
   });
 
   container.find("#injection_template_reset").off("click").on("click", async function () {
-    const confirm = await callGenericPopup("确定将当前方案恢复为系统默认模板吗？", POPUP_TYPE.CONFIRM);
-    if (!confirm) return;
     const targetSettings = getCharacterSettingsRoot();
     if (!targetSettings) return;
     ensureInjectionTemplatesInit(targetSettings);
 
     const currentId = targetSettings.injectionTemplates.currentPresetId || "默认方案";
-    targetSettings.injectionTemplates.presets[currentId] = getSystemDefaultInjectionTemplates();
+    const confirmReset = await callGenericPopup(`确定将方案 "${currentId}" 恢复为默认初始内容吗？`, POPUP_TYPE.CONFIRM);
+    if (!confirmReset) return;
+
+    const defaultContent = SYSTEM_INJECTION_TEMPLATES[currentId] || getSystemDefaultInjectionTemplates();
+    targetSettings.injectionTemplates.presets[currentId] = { ...defaultContent };
     saveSettingsDebounced();
     updateInjectionTemplateUI(container);
-    toastr.success(`方案 "${currentId}" 已重置为系统默认！`);
+    toastr.success(`方案 "${currentId}" 已重置为默认内容！`);
   });
 
   container.find("#injection_template_delete").off("click").on("click", async function () {
@@ -28495,19 +28530,19 @@ function setupInjectionTemplateControls(container) {
     ensureInjectionTemplatesInit(targetSettings);
 
     const currentId = targetSettings.injectionTemplates.currentPresetId || "默认方案";
-    if (currentId === "默认方案") {
-      toastr.warning("默认方案不可删除！");
+    if (SYSTEM_PRESET_IDS.includes(currentId)) {
+      toastr.warning(`系统预置方案 "${currentId}" 不可删除！`);
       return;
     }
 
-    const confirm = await callGenericPopup(`确定删除方案 "${currentId}" 吗？`, POPUP_TYPE.CONFIRM);
-    if (!confirm) return;
+    const confirmDelete = await callGenericPopup(`确定删除自定义方案 "${currentId}" 吗？`, POPUP_TYPE.CONFIRM);
+    if (!confirmDelete) return;
 
     delete targetSettings.injectionTemplates.presets[currentId];
     targetSettings.injectionTemplates.currentPresetId = "默认方案";
     saveSettingsDebounced();
     updateInjectionTemplateUI(container);
-    toastr.success(`方案 "${currentId}" 已删除！`);
+    toastr.success(`方案 "${currentId}" 已成功删除！`);
   });
 }
 

--- a/index.js
+++ b/index.js
@@ -22198,104 +22198,57 @@ function generateCharacterListText(triggerText = null) {
       continue;
     }
 
-    let outfitText = "";
-    if (Array.isArray(character.outfits) && character.outfits.length > 0) {
-      const outfitTexts = [];
-      for (const outfitId of character.outfits) {
-        const outfit = settings3.outfitPresets?.[outfitId];
-        if (!outfit) continue;
-        if (outfit.nameCN) {
-          outfitDetails.push(`
-  \u4E2D\u6587\u540D\u79F0\uFF1A${outfit.nameCN}`);
-        }
-        if (outfit.nameEN) {
-          const displayName = outfit.nameEN.split("|")[0].trim();
-          outfitDetails.push(`  \u82F1\u6587\u540D\u79F0\uFF1A${displayName}`);
-        }
-        if (outfit.upperBody) {
-          outfitDetails.push(`  \u4E0A\u534A\u8EAB\uFF08\u6B63\u9762\uFF09\uFF1A${outfit.upperBody}`);
-        }
-        if (outfit.upperBodyBack) {
-          outfitDetails.push(`  \u4E0A\u534A\u8EAB\uFF08\u80CC\u9762\uFF09\uFF1A${outfit.upperBodyBack}`);
-        }
-        if (outfit.fullBody) {
-          outfitDetails.push(`  \u4E0B\u534A\u8EAB\uFF08\u6B63\u9762\uFF09\uFF1A${outfit.fullBody}`);
-        }
-        if (outfit.fullBodyBack) {
-          outfitDetails.push(`  \u4E0B\u534A\u8EAB\uFF08\u80CC\u9762\uFF09\uFF1A${outfit.fullBodyBack}`);
-        }
-        if (outfitDetails.length > 0) {
-          charInfo.push(outfitDetails.join("\n"));
-        }
-      }
-    }
-    if (charInfo.length > 0) {
-      characterList.push(charInfo.join("\n"));
+    const charData = getCharacterPromptData(character, settings3);
+    const renderedChar = applyInjectionTemplate(activeTemplates.characterListTemplate, charData);
+    if (renderedChar) {
+      characterList.push(renderedChar);
     }
   }
-  return characterList.length > 0 ? characterList.join("\n\n") : "\uFF08\u6682\u65E0\u88AB\u89E6\u53D1\u7684\u89D2\u8272\uFF09";
+
+  return characterList.length > 0 ? characterList.join("\n\n") : "（暂无被触发的角色）";
 }
+
 function generateOutfitEnableListText() {
-  const settings3 = extension_settings20[extensionName];
+  const settings3 = getCharacterSettingsRoot();
   const enablePresetId = settings3.outfitEnablePresetId;
   const enablePreset = settings3.outfitEnablePresets?.[enablePresetId];
   if (!enablePreset || !Array.isArray(enablePreset.outfits) || enablePreset.outfits.length === 0) {
     return "\u6682\u672A\u914D\u7F6E\u901A\u7528\u670D\u88C5";
   }
+
+  const activeTemplates = getActiveInjectionTemplates(settings3);
   const outfitList = [];
+
   for (const outfitId of enablePreset.outfits) {
     const outfit = settings3.outfitPresets?.[outfitId];
     if (!outfit) continue;
-    const outfitInfo = [];
-    if (outfit.nameCN) {
-      outfitInfo.push(`\u4E2D\u6587\u540D\u79F0\uFF1A${outfit.nameCN}`);
-    }
-    if (outfit.nameEN) {
-      const displayName = outfit.nameEN.split("|")[0].trim();
-      outfitInfo.push(`\u82F1\u6587\u540D\u79F0\uFF1A${displayName}`);
-    }
-    if (outfit.upperBody) {
-      outfitInfo.push(`\u4E0A\u534A\u8EAB\uFF08\u6B63\u9762\uFF09\uFF1A${outfit.upperBody}`);
-    }
-    if (outfit.upperBodyBack) {
-      outfitInfo.push(`\u4E0A\u534A\u8EAB\uFF08\u80CC\u9762\uFF09\uFF1A${outfit.upperBodyBack}`);
-    }
-    if (outfit.fullBody) {
-      outfitInfo.push(`\u4E0B\u534A\u8EAB\uFF08\u6B63\u9762\uFF09\uFF1A${outfit.fullBody}`);
-    }
-    if (outfit.fullBodyBack) {
-      outfitInfo.push(`\u4E0B\u534A\u8EAB\uFF08\u80CC\u9762\uFF09\uFF1A${outfit.fullBodyBack}`);
-    }
-    if (outfitInfo.length > 0) {
-      outfitList.push(outfitInfo.join("\n"));
+
+    const outfitData = getOutfitPromptData(outfit);
+    const renderedOutfit = applyInjectionTemplate(activeTemplates.enableOutfitListTemplate, outfitData);
+    if (renderedOutfit) {
+      outfitList.push(renderedOutfit);
     }
   }
+
   return outfitList.join("\n\n");
 }
 function generateCommonCharacterListText() {
-  const settings3 = extension_settings20[extensionName];
+  const settings3 = getCharacterSettingsRoot();
   const enablePresetId = settings3.characterCommonPresetId;
   const enablePreset = settings3.characterCommonPresets?.[enablePresetId];
   if (!enablePreset || !Array.isArray(enablePreset.characters) || enablePreset.characters.length === 0) {
     return "\u6682\u672A\u914D\u7F6E\u901A\u7528\u89D2\u8272";
   }
+  const activeTemplates = getActiveInjectionTemplates(settings3);
   const characterList = [];
   for (const charId of enablePreset.characters) {
     const character = settings3.characterPresets?.[charId];
     if (!character) continue;
-    const charInfo = [];
-    if (character.nameCN) {
-      charInfo.push(character.nameCN);
-    }
-    if (character.nameEN) {
-      const displayName = character.nameEN.split("|")[0].trim();
-      charInfo.push(displayName);
-    }
-    if (charInfo.length > 0) {
-      characterList.push(charInfo.join(" "));
-    }
+    const charData = getCharacterPromptData(character, settings3);
+    const renderedChar = applyInjectionTemplate(activeTemplates.commonCharacterListTemplate, charData);
+    if (renderedChar) characterList.push(renderedChar);
   }
-  return characterList.join("\n");
+  return characterList.join("\n\n");
 }
 async function getEnabledCharacterImages(triggerText = null) {
   const { getConfigImage: getConfigImage2 } = await Promise.resolve().then(() => (init_configDatabase(), configDatabase_exports));
@@ -28081,13 +28034,100 @@ function getCharacterSettingsRoot() {
   return null;
 }
 
-function getSystemDefaultInjectionTemplates() {
+function getCharacterPromptData(character, settingsObj) {
+  if (!character) return {};
+  const settings = settingsObj || getCharacterSettingsRoot();
+
+  let outfitsJoined = "";
+  if (Array.isArray(character.outfits) && character.outfits.length > 0) {
+    const activeTpls = getActiveInjectionTemplates(settings);
+    const outfitLines = [];
+    for (const outfitId of character.outfits) {
+      const outfit = settings?.outfitPresets?.[outfitId];
+      if (!outfit) continue;
+      const outfitData = getOutfitPromptData(outfit);
+      const renderedOutfit = applyInjectionTemplate(activeTpls.innerOutfitTemplate, outfitData);
+      if (renderedOutfit) {
+        outfitLines.push(renderedOutfit);
+      }
+    }
+    outfitsJoined = outfitLines.join("\n");
+  }
+
+  const nameCN = character.nameCN || "";
+  const nameEN = character.nameEN ? character.nameEN.split("|")[0].trim() : "";
+
   return {
+    nameCN,
+    nameEN,
+    traits: character.characterTraits || "",
+    facial: character.facialFeatures || "",
+    facialBack: character.facialFeaturesBack || "",
+    upperSFW: character.upperBodySFW || "",
+    upperSFWBack: character.upperBodySFWBack || "",
+    fullSFW: character.fullBodySFW || "",
+    fullSFWBack: character.fullBodySFWBack || "",
+    lowerSFW: character.fullBodySFW || character.lowerBodySFW || "",
+    lowerSFWBack: character.fullBodySFWBack || character.lowerBodySFWBack || "",
+    upperNSFW: character.upperBodyNSFW || "",
+    upperNSFWBack: character.upperBodyNSFWBack || "",
+    fullNSFW: character.fullBodyNSFW || "",
+    fullNSFWBack: character.fullBodyNSFWBack || "",
+    lowerNSFW: character.fullBodyNSFW || character.lowerBodyNSFW || "",
+    lowerNSFWBack: character.fullBodyNSFWBack || character.lowerBodyNSFWBack || "",
+    outfit: outfitsJoined,
+    outfits: outfitsJoined
+  };
+}
+
+function getOutfitPromptData(outfit) {
+  if (!outfit) return {};
+  const nameCN = outfit.nameCN || "";
+  const nameEN = outfit.nameEN ? outfit.nameEN.split("|")[0].trim() : "";
+  const outfitName = nameCN || nameEN || "未知服装";
+
+  return {
+    nameCN,
+    nameEN,
+    outfitName,
+    upperBody: outfit.upperBody || outfit.upperBodySFW || "",
+    upperBodyBack: outfit.upperBodyBack || outfit.upperBodySFWBack || "",
+    fullBody: outfit.fullBody || outfit.fullBodySFW || "",
+    fullBodyBack: outfit.fullBodyBack || outfit.fullBodySFWBack || "",
+    lowerBody: outfit.fullBody || outfit.fullBodySFW || outfit.lowerBody || "",
+    lowerBodyBack: outfit.fullBodyBack || outfit.fullBodySFWBack || outfit.lowerBodyBack || "",
+    upperSFW: outfit.upperBody || outfit.upperBodySFW || "",
+    upperSFWBack: outfit.upperBodyBack || outfit.upperBodySFWBack || "",
+    fullSFW: outfit.fullBody || outfit.fullBodySFW || "",
+    fullSFWBack: outfit.fullBodyBack || outfit.fullBodySFWBack || "",
+    lowerSFW: outfit.fullBody || outfit.fullBodySFW || outfit.lowerSFW || "",
+    lowerSFWBack: outfit.fullBodyBack || outfit.fullBodySFWBack || outfit.lowerSFWBack || "",
+    upperNSFW: outfit.upperBodyNSFW || "",
+    upperNSFWBack: outfit.upperBodyNSFWBack || "",
+    fullNSFW: outfit.fullBodyNSFW || "",
+    fullNSFWBack: outfit.fullBodyNSFWBack || "",
+    lowerNSFW: outfit.fullBodyNSFW || outfit.lowerNSFW || "",
+    lowerNSFWBack: outfit.fullBodyNSFWBack || outfit.lowerNSFWBack || ""
+  };
+}
+
+const QUICK_INJECTION_TEMPLATES = {
+  default_native: {
     characterListTemplate: `{nameCN} ({nameEN})\n角色特征:\n{traits}\n五官外貌:\n{facial}\n{facialBack}\nSFW:\n{upperSFW}\n{upperSFWBack}\n{fullSFW}\n{fullSFWBack}\nNSFW:\n{upperNSFW}\n{upperNSFWBack}\n{fullNSFW}\n{fullNSFWBack}\n{outfit}`,
     innerOutfitTemplate: `{outfitName}\nSFW:\n{upperSFW}\n{upperSFWBack}\n{fullSFW}\n{fullSFWBack}\nNSFW:\n{upperNSFW}\n{upperNSFWBack}\n{fullNSFW}\n{fullNSFWBack}`,
     commonCharacterListTemplate: `{nameCN} ({nameEN})\n角色特征:\n{traits}\n五官外貌:\n{facial}\n{facialBack}\nSFW:\n{upperSFW}\n{upperSFWBack}\n{fullSFW}\n{fullSFWBack}\nNSFW:\n{upperNSFW}\n{upperNSFWBack}\n{fullNSFW}\n{fullNSFWBack}`,
     enableOutfitListTemplate: `{outfitName}\nSFW:\n{upperSFW}\n{upperSFWBack}\n{fullSFW}\n{fullSFWBack}\nNSFW:\n{upperNSFW}\n{upperNSFWBack}\n{fullNSFW}\n{fullNSFWBack}`
-  };
+  },
+  tavern_xml: {
+    characterListTemplate: `<character name="{nameCN}" english_name="{nameEN}">\n  <traits>{traits}</traits>\n  <appearance>{facial} {facialBack}</appearance>\n  <clothing>{upperSFW}, {fullSFW}</clothing>\n  <outfits>\n{outfit}\n  </outfits>\n</character>`,
+    innerOutfitTemplate: `  <outfit name="{outfitName}">\n    <upper>{upperBody}</upper>\n    <lower>{fullBody}</lower>\n  </outfit>`,
+    commonCharacterListTemplate: `<common_character name="{nameCN}" english_name="{nameEN}">\n  <traits>{traits}</traits>\n  <appearance>{facial}</appearance>\n  <clothing>{upperSFW}, {fullSFW}</clothing>\n</common_character>`,
+    enableOutfitListTemplate: `<common_outfit name="{outfitName}">\n  <upper>{upperBody}</upper>\n  <lower>{fullBody}</lower>\n</common_outfit>`
+  }
+};
+
+function getSystemDefaultInjectionTemplates() {
+  return QUICK_INJECTION_TEMPLATES.default_native;
 }
 
 function ensureInjectionTemplatesInit(settingsObj) {
@@ -28122,8 +28162,9 @@ function applyInjectionTemplate(templateStr, dataMap) {
 
   let replaced = templateStr;
   for (const [key, val] of Object.entries(dataMap || {})) {
-    const regex = new RegExp(`\\{${key}\\}`, "g");
-    replaced = replaced.replace(regex, val != null ? String(val) : "");
+    const valStr = val != null ? String(val) : "";
+    const regex = new RegExp(`\\{\\{?${key}\\}?\\}`, "g");
+    replaced = replaced.replace(regex, valStr);
   }
 
   const lines = replaced.split(/\r?\n/);
@@ -28134,7 +28175,7 @@ function applyInjectionTemplate(templateStr, dataMap) {
     const trimmedLine = rawLine.trim();
 
     const rawTemplateLine = (templateStr.split(/\r?\n/)[i] || "");
-    const hadPlaceholder = /\{[a-zA-Z0-9_]+\}/.test(rawTemplateLine);
+    const hadPlaceholder = /\{\{?[a-zA-Z0-9_]+\}?\}/.test(rawTemplateLine);
 
     if (hadPlaceholder) {
       const textOnly = trimmedLine.replace(/[\s:：,，\-–—]/g, "");
@@ -28151,27 +28192,95 @@ function applyInjectionTemplate(templateStr, dataMap) {
 }
 
 function renderInjectionTemplateLivePreview(container) {
-  const sampleData = {
-    nameCN: "示例角色",
-    nameEN: "SampleChar",
-    traits: "1girl, solo, masterpiece",
-    facial: "blue eyes, long blonde hair",
-    facialBack: "",
-    upperSFW: "white shirt",
-    upperSFWBack: "",
-    fullSFW: "blue skirt",
-    fullSFWBack: "",
-    upperNSFW: "",
-    upperNSFWBack: "",
-    fullNSFW: "",
-    fullNSFWBack: "",
-    outfit: "水手服 (SFW: white shirt, blue skirt)",
-    outfitName: "示例服装"
-  };
-
   const charTpl = container.find("#tpl_characterListTemplate").val() || "";
-  const previewText = applyInjectionTemplate(charTpl, sampleData);
-  container.find("#tpl_live_preview").val(previewText);
+  const innerOutfitTpl = container.find("#tpl_innerOutfitTemplate").val() || "";
+  const commonCharTpl = container.find("#tpl_commonCharacterListTemplate").val() || "";
+  const enableOutfitTpl = container.find("#tpl_enableOutfitListTemplate").val() || "";
+
+  const sampleOutfit1 = getOutfitPromptData({
+    nameCN: "JK制服",
+    nameEN: "JK Uniform",
+    upperBody: "white collared shirt, red ribbon",
+    upperBodyBack: "sailor collar back",
+    fullBody: "pleated navy skirt",
+    fullBodyBack: "pleated skirt back",
+    lowerBody: "pleated navy skirt, white thighhighs",
+    lowerBodyBack: "skirt back hem"
+  });
+  const renderedInnerOutfit1 = applyInjectionTemplate(innerOutfitTpl, sampleOutfit1);
+
+  const sampleChar1 = {
+    nameCN: "爱丽丝",
+    nameEN: "Alice",
+    traits: "1girl, solo, masterpiece, blonde hair, blue eyes",
+    facial: "cute smile, delicate face",
+    facialBack: "long flowing blonde hair",
+    upperSFW: "pale skin, slender arms, collarbone",
+    upperSFWBack: "slender spine, shoulder blades",
+    fullSFW: "long legs, thigh gap",
+    fullSFWBack: "gluteal fold",
+    lowerSFW: "long legs, thigh gap",
+    lowerSFWBack: "gluteal fold",
+    upperNSFW: "small breasts, pink nipples",
+    upperNSFWBack: "waist dimples, smooth back",
+    fullNSFW: "shaved pussy",
+    fullNSFWBack: "plump butt",
+    lowerNSFW: "shaved pussy",
+    lowerNSFWBack: "plump butt",
+    outfit: renderedInnerOutfit1,
+    outfits: renderedInnerOutfit1
+  };
+  const renderedChar1 = applyInjectionTemplate(charTpl, sampleChar1);
+
+  const sampleChar2 = {
+    nameCN: "贝蒂",
+    nameEN: "Betty",
+    traits: "1girl, solo, silver hair, red eyes",
+    facial: "cool expression, twin braids",
+    facialBack: "twin braids back",
+    upperSFW: "fair skin, toned waist",
+    upperSFWBack: "back curvature",
+    fullSFW: "thick thighs",
+    fullSFWBack: "plump glutes",
+    lowerSFW: "thick thighs",
+    lowerSFWBack: "plump glutes"
+  };
+  const renderedChar2 = applyInjectionTemplate(charTpl, sampleChar2);
+
+  const sampleCommonChar1 = applyInjectionTemplate(commonCharTpl, {
+    nameCN: "路人A",
+    nameEN: "Passerby A",
+    traits: "1boy, short brown hair",
+    facial: "glasses",
+    facialBack: "neat short hair back",
+    upperSFW: "casual physique",
+    fullSFW: "straight legs",
+    lowerSFW: "straight legs"
+  });
+
+  const sampleCommonOutfit1 = applyInjectionTemplate(enableOutfitTpl, getOutfitPromptData({
+    nameCN: "运动服",
+    nameEN: "Tracksuit",
+    upperBody: "zipper jacket, athletic wear",
+    upperBodyBack: "sports logo on back",
+    fullBody: "track pants, sneakers",
+    fullBodyBack: "pants back seam",
+    lowerBody: "track pants, sneakers",
+    lowerBodyBack: "pants back seam"
+  }));
+
+  const previewSections = [];
+  previewSections.push("=== 【角色启用列表】 ===");
+  if (renderedChar1) previewSections.push(renderedChar1);
+  if (renderedChar2) previewSections.push(renderedChar2);
+
+  previewSections.push("\n=== 【通用角色列表】 ===");
+  if (sampleCommonChar1) previewSections.push(sampleCommonChar1);
+
+  previewSections.push("\n=== 【通用服装列表】 ===");
+  if (sampleCommonOutfit1) previewSections.push(sampleCommonOutfit1);
+
+  container.find("#tpl_live_preview").val(previewSections.join("\n\n"));
 }
 
 function updateInjectionTemplateUI(container) {
@@ -28200,6 +28309,77 @@ function updateInjectionTemplateUI(container) {
 
 function setupInjectionTemplateControls(container) {
   updateInjectionTemplateUI(container);
+
+  container.find(".st-chatu8-var-btn").off("click").on("click", function (e) {
+    e.preventDefault();
+    const targetId = $(this).attr("data-target") || $(this).data("target");
+    const varTag = $(this).attr("data-var") || $(this).data("var");
+    if (!targetId || !varTag) return;
+
+    const $textarea = container.find("#" + targetId);
+    if ($textarea.length === 0) return;
+
+    const el = $textarea[0];
+    const start = el.selectionStart || 0;
+    const end = el.selectionEnd || 0;
+    const val = $textarea.val();
+
+    const newVal = val.substring(0, start) + varTag + val.substring(end);
+    $textarea.val(newVal);
+
+    el.focus();
+    el.selectionStart = el.selectionEnd = start + varTag.length;
+
+    $textarea.trigger("input");
+
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(varTag).catch(() => {});
+    }
+
+    if (typeof toastr !== "undefined") {
+      toastr.info(`已插入变量 ${varTag}`);
+    }
+  });
+
+  container.find("#injection_template_refresh_preview").off("click").on("click", function () {
+    renderInjectionTemplateLivePreview(container);
+    if (typeof toastr !== "undefined") {
+      toastr.success("全量实时预览已刷新！");
+    }
+  });
+
+  container.find("#injection_template_apply_quick").off("click").on("click", function () {
+    const quickKey = container.find("#injection_template_quick_preset").val();
+    const quickTpls = QUICK_INJECTION_TEMPLATES[quickKey];
+    if (!quickTpls) {
+      if (typeof toastr !== "undefined") toastr.error("未找到对应的快捷模板方案！");
+      return;
+    }
+
+    container.find("#tpl_characterListTemplate").val(quickTpls.characterListTemplate || "");
+    container.find("#tpl_innerOutfitTemplate").val(quickTpls.innerOutfitTemplate || "");
+    container.find("#tpl_commonCharacterListTemplate").val(quickTpls.commonCharacterListTemplate || "");
+    container.find("#tpl_enableOutfitListTemplate").val(quickTpls.enableOutfitListTemplate || "");
+
+    renderInjectionTemplateLivePreview(container);
+
+    const targetSettings = getCharacterSettingsRoot();
+    if (targetSettings) {
+      ensureInjectionTemplatesInit(targetSettings);
+      const currentId = targetSettings.injectionTemplates.currentPresetId || "默认方案";
+      targetSettings.injectionTemplates.presets[currentId] = {
+        characterListTemplate: container.find("#tpl_characterListTemplate").val(),
+        innerOutfitTemplate: container.find("#tpl_innerOutfitTemplate").val(),
+        commonCharacterListTemplate: container.find("#tpl_commonCharacterListTemplate").val(),
+        enableOutfitListTemplate: container.find("#tpl_enableOutfitListTemplate").val()
+      };
+      saveSettingsDebounced();
+    }
+
+    if (typeof toastr !== "undefined") {
+      toastr.success("已载入快捷模板并自动同步至当前方案！");
+    }
+  });
 
   container.find("#injection_template_preset_id").off("change").on("change", function () {
     const selectedId = $(this).val();
@@ -28369,6 +28549,7 @@ function refreshCharacterSettings(container) {
   loadCharacterCommonSelector();
   loadBananaCharacterPresetList();
   loadBananaCharacterPreset();
+  updateInjectionTemplateUI(container);
   refreshAllSelectSearch();
   resetSubNavigation(container);
   console.log("[Character] Character settings refreshed");

--- a/index.js
+++ b/index.js
@@ -28116,22 +28116,22 @@ const SYSTEM_PRESET_IDS = ["默认方案", "Tavern XML 格式", "Markdown 极简
 
 const SYSTEM_INJECTION_TEMPLATES = {
   "默认方案": {
-    characterListTemplate: `中文名称：{nameCN}\n英文名称：{nameEN}\n角色特征：{traits}\n五官外貌（正面）：{facial}\n五官外貌（背面）：{facialBack}\n上半身SFW（正面）：{upperSFW}\n上半身SFW（背面）：{upperSFWBack}\n下半身SFW（正面）：{lowerSFW}\n下半身SFW（背面）：{lowerSFWBack}\n上半身NSFW（正面）：{upperNSFW}\n上半身NSFW（背面）：{upperNSFWBack}\n下半身NSFW（正面）：{lowerNSFW}\n下半身NSFW（背面）：{lowerNSFWBack}\n服装列表：\n{outfits}`,
+    characterListTemplate: `中文名称：{nameCN}\n英文名称：{nameEN}\n角色特征：{traits}\n五官外貌（正面）：{facial}\n五官外貌（背面）：{facialBack}\n上半身SFW（正面）：{upperSFW}\n上半身SFW（背面）：{upperSFWBack}\n下半身SFW（正面）：{lowerSFW}\n下半身SFW（背面）：{lowerSFWBack}\n上半身NSFW（正面）：{upperNSFW}\n上半身NSFW（背面）：{upperNSFWBack}\n下半身NSFW（正面）：{lowerNSFW}\n下半身NSFW（背面）：{lowerNSFWBack}\n负向提示词：{negative}\n服装列表：\n{outfits}`,
     innerOutfitTemplate: `  中文名称：{nameCN}\n  英文名称：{nameEN}\n  上半身（正面）：{upperBody}\n  上半身（背面）：{upperBodyBack}\n  下半身（正面）：{fullBody}\n  下半身（背面）：{fullBodyBack}`,
-    commonCharacterListTemplate: `中文名称：{nameCN}\n英文名称：{nameEN}\n角色特征：{traits}\n五官外貌（正面）：{facial}\n五官外貌（背面）：{facialBack}\n上半身SFW（正面）：{upperSFW}\n上半身SFW（背面）：{upperSFWBack}\n下半身SFW（正面）：{lowerSFW}\n下半身SFW（背面）：{lowerSFWBack}\n上半身NSFW（正面）：{upperNSFW}\n上半身NSFW（背面）：{upperNSFWBack}\n下半身NSFW（正面）：{lowerNSFW}\n下半身NSFW（背面）：{lowerNSFWBack}`,
+    commonCharacterListTemplate: `中文名称：{nameCN}\n英文名称：{nameEN}\n角色特征：{traits}\n五官外貌（正面）：{facial}\n五官外貌（背面）：{facialBack}\n上半身SFW（正面）：{upperSFW}\n上半身SFW（背面）：{upperSFWBack}\n下半身SFW（正面）：{lowerSFW}\n下半身SFW（背面）：{lowerSFWBack}\n上半身NSFW（正面）：{upperNSFW}\n上半身NSFW（背面）：{upperNSFWBack}\n下半身NSFW（正面）：{lowerNSFW}\n下半身NSFW（背面）：{lowerNSFWBack}\n负向提示词：{negative}`,
     enableOutfitListTemplate: `中文名称：{nameCN}\n英文名称：{nameEN}\n上半身（正面）：{upperBody}\n上半身（背面）：{upperBodyBack}\n下半身（正面）：{fullBody}\n下半身（背面）：{fullBodyBack}`
   },
   "Tavern XML 格式": {
-    characterListTemplate: `<character name="{nameCN}" english_name="{nameEN}">\n  <traits>{traits}</traits>\n  <appearance>Front: {facial} | Back: {facialBack}</appearance>\n  <body_sfw>Upper: {upperSFW} ({upperSFWBack}) | Lower: {lowerSFW} ({lowerSFWBack})</body_sfw>\n  <body_nsfw>Upper: {upperNSFW} ({upperNSFWBack}) | Lower: {lowerNSFW} ({lowerNSFWBack})</body_nsfw>\n  <outfits>\n{outfits}\n  </outfits>\n</character>`,
-    innerOutfitTemplate: `  <outfit name="{nameCN}" english_name="{nameEN}">\n    <upper>Front: {upperBody} | Back: {upperBodyBack}</upper>\n    <lower>Front: {fullBody} | Back: {fullBodyBack}</lower>\n  </outfit>`,
-    commonCharacterListTemplate: `<common_character name="{nameCN}" english_name="{nameEN}">\n  <traits>{traits}</traits>\n  <appearance>Front: {facial} | Back: {facialBack}</appearance>\n  <body_sfw>Upper: {upperSFW} | Lower: {lowerSFW}</body_sfw>\n</common_character>`,
-    enableOutfitListTemplate: `<common_outfit name="{nameCN}" english_name="{nameEN}">\n  <upper>Front: {upperBody} | Back: {upperBodyBack}</upper>\n  <lower>Front: {fullBody} | Back: {fullBodyBack}</lower>\n</common_outfit>`
+    characterListTemplate: `<character id="{nameEN}" cn="{nameCN}">\n  [Traits] {traits}\n  [Face] Front: {facial} | Back: {facialBack}\n  [Body-SFW] Front: {upperSFW}, {lowerSFW} | Back: {upperSFWBack}, {lowerSFWBack}\n  [Body-NSFW] Front: {upperNSFW}, {lowerNSFW} | Back: {upperNSFWBack}, {lowerNSFWBack}\n  [Negative] {negative}\n  [Outfits]\n{outfits}\n</character>`,
+    innerOutfitTemplate: `  <outfit name="{nameEN}" cn="{nameCN}">\n    [Upper] Front: {upperBody} | Back: {upperBodyBack}\n    [Full] Front: {fullBody} | Back: {fullBodyBack}\n  </outfit>`,
+    commonCharacterListTemplate: `<common_character id="{nameEN}" cn="{nameCN}">\n  [Traits] {traits}\n  [Face] Front: {facial} | Back: {facialBack}\n  [Body-SFW] Front: {upperSFW}, {lowerSFW} | Back: {upperSFWBack}, {lowerSFWBack}\n  [Negative] {negative}\n</common_character>`,
+    enableOutfitListTemplate: `<common_outfit id="{nameEN}" cn="{nameCN}">\n  [Upper] Front: {upperBody} | Back: {upperBodyBack}\n  [Full] Front: {fullBody} | Back: {fullBodyBack}\n</common_outfit>`
   },
   "Markdown 极简卡片": {
-    characterListTemplate: `### 角色：{nameCN} ({nameEN})\n- **特征**: {traits}\n- **面部**: {facial} (背面: {facialBack})\n- **体型SFW**: 上身({upperSFW} / {upperSFWBack}), 下身({lowerSFW} / {lowerSFWBack})\n- **解剖NSFW**: 上身({upperNSFW} / {upperNSFWBack}), 下身({lowerNSFW} / {lowerNSFWBack})\n- **服装**:\n{outfits}`,
-    innerOutfitTemplate: `  * 服装：{nameCN} ({nameEN}) -> 上身: {upperBody} ({upperBodyBack}) | 下身: {fullBody} ({fullBodyBack})`,
-    commonCharacterListTemplate: `### 通用角色：{nameCN} ({nameEN})\n- **特征**: {traits}\n- **面部**: {facial}\n- **体型**: {upperSFW}, {lowerSFW}`,
-    enableOutfitListTemplate: `### 通用服装：{nameCN} ({nameEN})\n- **上身**: {upperBody} ({upperBodyBack})\n- **下身**: {fullBody} ({fullBodyBack})`
+    characterListTemplate: `### 角色：{nameCN} ({nameEN})\n- 特征: {traits}\n- 五官: {facial} | 背面: {facialBack}\n- SFW体型: 上身: {upperSFW} ({upperSFWBack}) | 下身: {lowerSFW} ({lowerSFWBack})\n- NSFW解剖: 上身: {upperNSFW} ({upperNSFWBack}) | 下身: {lowerNSFW} ({lowerNSFWBack})\n- 负面提示词: {negative}\n- 服装列表:\n{outfits}`,
+    innerOutfitTemplate: `  * 服装: {nameCN} ({nameEN})\n    - 上身: {upperBody} | 背面: {upperBodyBack}\n    - 下身: {fullBody} | 背面: {fullBodyBack}`,
+    commonCharacterListTemplate: `### 通用角色：{nameCN} ({nameEN})\n- 特征: {traits}\n- 五官: {facial} | 背面: {facialBack}\n- SFW体型: 上身: {upperSFW} ({upperSFWBack}) | 下身: {lowerSFW} ({lowerSFWBack})\n- 负面提示词: {negative}`,
+    enableOutfitListTemplate: `### 通用服装：{nameCN} ({nameEN})\n- 上身: {upperBody} | 背面: {upperBodyBack}\n- 下身: {fullBody} | 背面: {fullBodyBack}`
   }
 };
 
@@ -28152,7 +28152,8 @@ function ensureInjectionTemplatesInit(settingsObj) {
     target.injectionTemplates.presets = {};
   }
   for (const [id, sysTpl] of Object.entries(SYSTEM_INJECTION_TEMPLATES)) {
-    if (!target.injectionTemplates.presets[id]) {
+    const existing = target.injectionTemplates.presets[id];
+    if (!existing || existing.characterListTemplate?.includes("<character name=") || !existing.characterListTemplate?.includes("负向提示词")) {
       target.injectionTemplates.presets[id] = { ...sysTpl };
     }
   }

--- a/index.js
+++ b/index.js
@@ -22180,68 +22180,30 @@ function inspectCharacterListTrigger(triggerText) {
   };
 }
 function generateCharacterListText(triggerText = null) {
-  const settings3 = extension_settings20[extensionName];
+  const settings3 = getCharacterSettingsRoot();
+  if (!settings3) return "（暂无启用的角色）";
   const enablePresetId = settings3.characterEnablePresetId;
   const enablePreset = settings3.characterEnablePresets?.[enablePresetId];
   if (!enablePreset || !Array.isArray(enablePreset.characters) || enablePreset.characters.length === 0) {
-    return "\uFF08\u6682\u65E0\u542F\u7528\u7684\u89D2\u8272\uFF09";
+    return "（暂无启用的角色）";
   }
+
+  const activeTemplates = getActiveInjectionTemplates(settings3);
   const characterList = [];
+
   for (const charId of enablePreset.characters) {
     const character = settings3.characterPresets?.[charId];
     if (!character) continue;
-    if (triggerText !== null) {
-      if (!isCharacterTriggered(character, triggerText)) {
-        continue;
-      }
+    if (triggerText !== null && typeof isCharacterTriggered === "function" && !isCharacterTriggered(character, triggerText)) {
+      continue;
     }
-    const charInfo = [];
-    if (character.nameCN) {
-      charInfo.push(`\u4E2D\u6587\u540D\u79F0\uFF1A${character.nameCN}`);
-    }
-    if (character.nameEN) {
-      const displayName = character.nameEN.split("|")[0].trim();
-      charInfo.push(`\u82F1\u6587\u540D\u79F0\uFF1A${displayName}`);
-    }
-    if (character.characterTraits) {
-      charInfo.push(`\u89D2\u8272\u7279\u5F81\uFF1A${character.characterTraits}`);
-    }
-    if (character.facialFeatures) {
-      charInfo.push(`\u4E94\u5B98\u5916\u8C8C\uFF08\u6B63\u9762\uFF09\uFF1A${character.facialFeatures}`);
-    }
-    if (character.facialFeaturesBack) {
-      charInfo.push(`\u4E94\u5B98\u5916\u8C8C\uFF08\u80CC\u9762\uFF09\uFF1A${character.facialFeaturesBack}`);
-    }
-    if (character.upperBodySFW) {
-      charInfo.push(`\u4E0A\u534A\u8EABSFW\uFF08\u6B63\u9762\uFF09\uFF1A${character.upperBodySFW}`);
-    }
-    if (character.upperBodySFWBack) {
-      charInfo.push(`\u4E0A\u534A\u8EABSFW\uFF08\u80CC\u9762\uFF09\uFF1A${character.upperBodySFWBack}`);
-    }
-    if (character.fullBodySFW) {
-      charInfo.push(`\u4E0B\u534A\u8EABSFW\uFF08\u6B63\u9762\uFF09\uFF1A${character.fullBodySFW}`);
-    }
-    if (character.fullBodySFWBack) {
-      charInfo.push(`\u4E0B\u534A\u8EABSFW\uFF08\u80CC\u9762\uFF09\uFF1A${character.fullBodySFWBack}`);
-    }
-    if (character.upperBodyNSFW) {
-      charInfo.push(`\u4E0A\u534A\u8EABNSFW\uFF08\u6B63\u9762\uFF09\uFF1A${character.upperBodyNSFW}`);
-    }
-    if (character.upperBodyNSFWBack) {
-      charInfo.push(`\u4E0A\u534A\u8EABNSFW\uFF08\u80CC\u9762\uFF09\uFF1A${character.upperBodyNSFWBack}`);
-    }
-    if (character.fullBodyNSFW) {
-      charInfo.push(`\u4E0B\u534A\u8EABNSFW\uFF08\u6B63\u9762\uFF09\uFF1A${character.fullBodyNSFW}`);
-    }
-    if (character.fullBodyNSFWBack) {
-      charInfo.push(`\u4E0B\u534A\u8EABNSFW\uFF08\u80CC\u9762\uFF09\uFF1A${character.fullBodyNSFWBack}`);
-    }
+
+    let outfitText = "";
     if (Array.isArray(character.outfits) && character.outfits.length > 0) {
-      charInfo.push(`\u670D\u88C5\u5217\u8868\uFF1A`);
+      const outfitTexts = [];
       for (const outfitId of character.outfits) {
         const outfit = settings3.outfitPresets?.[outfitId];
         if (!outfit) continue;
-        const outfitDetails = [];
         if (outfit.nameCN) {
           outfitDetails.push(`
   \u4E2D\u6587\u540D\u79F0\uFF1A${outfit.nameCN}`);
@@ -28107,6 +28069,268 @@ var init_selectSearch = __esm({
   }
 });
 
+// utils/settings/character/injectionTemplates.js (全新模块)
+
+function getCharacterSettingsRoot() {
+  if (typeof extension_settings31 !== "undefined" && extension_settings31[extensionName]) {
+    return extension_settings31[extensionName];
+  }
+  if (typeof extension_settings !== "undefined" && extension_settings[extensionName]) {
+    return extension_settings[extensionName];
+  }
+  return null;
+}
+
+function getSystemDefaultInjectionTemplates() {
+  return {
+    characterListTemplate: `{nameCN} ({nameEN})\n角色特征:\n{traits}\n五官外貌:\n{facial}\n{facialBack}\nSFW:\n{upperSFW}\n{upperSFWBack}\n{fullSFW}\n{fullSFWBack}\nNSFW:\n{upperNSFW}\n{upperNSFWBack}\n{fullNSFW}\n{fullNSFWBack}\n{outfit}`,
+    innerOutfitTemplate: `{outfitName}\nSFW:\n{upperSFW}\n{upperSFWBack}\n{fullSFW}\n{fullSFWBack}\nNSFW:\n{upperNSFW}\n{upperNSFWBack}\n{fullNSFW}\n{fullNSFWBack}`,
+    commonCharacterListTemplate: `{nameCN} ({nameEN})\n角色特征:\n{traits}\n五官外貌:\n{facial}\n{facialBack}\nSFW:\n{upperSFW}\n{upperSFWBack}\n{fullSFW}\n{fullSFWBack}\nNSFW:\n{upperNSFW}\n{upperNSFWBack}\n{fullNSFW}\n{fullNSFWBack}`,
+    enableOutfitListTemplate: `{outfitName}\nSFW:\n{upperSFW}\n{upperSFWBack}\n{fullSFW}\n{fullSFWBack}\nNSFW:\n{upperNSFW}\n{upperNSFWBack}\n{fullNSFW}\n{fullNSFWBack}`
+  };
+}
+
+function ensureInjectionTemplatesInit(settingsObj) {
+  const target = settingsObj || getCharacterSettingsRoot();
+  if (!target) return;
+  if (!target.injectionTemplates || !target.injectionTemplates.presets) {
+    target.injectionTemplates = {
+      presets: {
+        "默认方案": getSystemDefaultInjectionTemplates()
+      },
+      currentPresetId: "默认方案"
+    };
+  }
+}
+
+function getActiveInjectionTemplates(settingsObj) {
+  const target = settingsObj || getCharacterSettingsRoot();
+  ensureInjectionTemplatesInit(target);
+  const defaults = getSystemDefaultInjectionTemplates();
+  const currentId = target?.injectionTemplates?.currentPresetId || "默认方案";
+  const userPreset = target?.injectionTemplates?.presets?.[currentId] || {};
+  return {
+    characterListTemplate: userPreset.characterListTemplate ?? defaults.characterListTemplate,
+    innerOutfitTemplate: userPreset.innerOutfitTemplate ?? defaults.innerOutfitTemplate,
+    commonCharacterListTemplate: userPreset.commonCharacterListTemplate ?? defaults.commonCharacterListTemplate,
+    enableOutfitListTemplate: userPreset.enableOutfitListTemplate ?? defaults.enableOutfitListTemplate
+  };
+}
+
+function applyInjectionTemplate(templateStr, dataMap) {
+  if (!templateStr || typeof templateStr !== "string") return "";
+
+  let replaced = templateStr;
+  for (const [key, val] of Object.entries(dataMap || {})) {
+    const regex = new RegExp(`\\{${key}\\}`, "g");
+    replaced = replaced.replace(regex, val != null ? String(val) : "");
+  }
+
+  const lines = replaced.split(/\r?\n/);
+  const cleanedLines = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const rawLine = lines[i];
+    const trimmedLine = rawLine.trim();
+
+    const rawTemplateLine = (templateStr.split(/\r?\n/)[i] || "");
+    const hadPlaceholder = /\{[a-zA-Z0-9_]+\}/.test(rawTemplateLine);
+
+    if (hadPlaceholder) {
+      const textOnly = trimmedLine.replace(/[\s:：,，\-–—]/g, "");
+      if (!textOnly) {
+        continue;
+      }
+    }
+    cleanedLines.push(rawLine);
+  }
+
+  let result = cleanedLines.join("\n").replace(/\n{3,}/g, "\n\n").trim();
+  result = result.replace(/,\s*$/g, "");
+  return result;
+}
+
+function renderInjectionTemplateLivePreview(container) {
+  const sampleData = {
+    nameCN: "示例角色",
+    nameEN: "SampleChar",
+    traits: "1girl, solo, masterpiece",
+    facial: "blue eyes, long blonde hair",
+    facialBack: "",
+    upperSFW: "white shirt",
+    upperSFWBack: "",
+    fullSFW: "blue skirt",
+    fullSFWBack: "",
+    upperNSFW: "",
+    upperNSFWBack: "",
+    fullNSFW: "",
+    fullNSFWBack: "",
+    outfit: "水手服 (SFW: white shirt, blue skirt)",
+    outfitName: "示例服装"
+  };
+
+  const charTpl = container.find("#tpl_characterListTemplate").val() || "";
+  const previewText = applyInjectionTemplate(charTpl, sampleData);
+  container.find("#tpl_live_preview").val(previewText);
+}
+
+function updateInjectionTemplateUI(container) {
+  const targetSettings = getCharacterSettingsRoot();
+  if (!targetSettings) return;
+  ensureInjectionTemplatesInit(targetSettings);
+
+  const presets = targetSettings.injectionTemplates.presets;
+  const currentId = targetSettings.injectionTemplates.currentPresetId || "默认方案";
+
+  const $select = container.find("#injection_template_preset_id");
+  $select.empty();
+  Object.keys(presets).forEach((id) => {
+    $select.append(`<option value="${id}">${id}</option>`);
+  });
+  $select.val(currentId);
+
+  const activeTpls = presets[currentId] || getSystemDefaultInjectionTemplates();
+  container.find("#tpl_characterListTemplate").val(activeTpls.characterListTemplate || "");
+  container.find("#tpl_innerOutfitTemplate").val(activeTpls.innerOutfitTemplate || "");
+  container.find("#tpl_commonCharacterListTemplate").val(activeTpls.commonCharacterListTemplate || "");
+  container.find("#tpl_enableOutfitListTemplate").val(activeTpls.enableOutfitListTemplate || "");
+
+  renderInjectionTemplateLivePreview(container);
+}
+
+function setupInjectionTemplateControls(container) {
+  updateInjectionTemplateUI(container);
+
+  container.find("#injection_template_preset_id").off("change").on("change", function () {
+    const selectedId = $(this).val();
+    const targetSettings = getCharacterSettingsRoot();
+    if (!targetSettings) return;
+    ensureInjectionTemplatesInit(targetSettings);
+    targetSettings.injectionTemplates.currentPresetId = selectedId;
+    saveSettingsDebounced();
+    updateInjectionTemplateUI(container);
+  });
+
+  container.find("#tpl_characterListTemplate, #tpl_innerOutfitTemplate, #tpl_commonCharacterListTemplate, #tpl_enableOutfitListTemplate")
+    .off("input").on("input", function () {
+      renderInjectionTemplateLivePreview(container);
+    });
+
+  container.find("#injection_template_update").off("click").on("click", function () {
+    const targetSettings = getCharacterSettingsRoot();
+    if (!targetSettings) return;
+    ensureInjectionTemplatesInit(targetSettings);
+
+    const currentId = targetSettings.injectionTemplates.currentPresetId || "默认方案";
+    targetSettings.injectionTemplates.presets[currentId] = {
+      characterListTemplate: container.find("#tpl_characterListTemplate").val(),
+      innerOutfitTemplate: container.find("#tpl_innerOutfitTemplate").val(),
+      commonCharacterListTemplate: container.find("#tpl_commonCharacterListTemplate").val(),
+      enableOutfitListTemplate: container.find("#tpl_enableOutfitListTemplate").val()
+    };
+    saveSettingsDebounced();
+    toastr.success(`方案 "${currentId}" 保存成功！`);
+  });
+
+  container.find("#injection_template_new").off("click").on("click", async function () {
+    const newName = await callGenericPopup("请输入新提示词注入方案名称：", POPUP_TYPE.INPUT, "");
+    if (!newName || !newName.trim()) return;
+    const targetSettings = getCharacterSettingsRoot();
+    if (!targetSettings) return;
+    ensureInjectionTemplatesInit(targetSettings);
+
+    const id = newName.trim();
+    if (targetSettings.injectionTemplates.presets[id]) {
+      toastr.error(`方案 "${id}" 已存在！`);
+      return;
+    }
+
+    targetSettings.injectionTemplates.presets[id] = getSystemDefaultInjectionTemplates();
+    targetSettings.injectionTemplates.currentPresetId = id;
+    saveSettingsDebounced();
+    updateInjectionTemplateUI(container);
+    toastr.success(`新建方案 "${id}" 成功！`);
+  });
+
+  container.find("#injection_template_save_as").off("click").on("click", async function () {
+    const newName = await callGenericPopup("请输入另存为的新方案名称：", POPUP_TYPE.INPUT, "");
+    if (!newName || !newName.trim()) return;
+    const targetSettings = getCharacterSettingsRoot();
+    if (!targetSettings) return;
+    ensureInjectionTemplatesInit(targetSettings);
+
+    const id = newName.trim();
+    targetSettings.injectionTemplates.presets[id] = {
+      characterListTemplate: container.find("#tpl_characterListTemplate").val(),
+      innerOutfitTemplate: container.find("#tpl_innerOutfitTemplate").val(),
+      commonCharacterListTemplate: container.find("#tpl_commonCharacterListTemplate").val(),
+      enableOutfitListTemplate: container.find("#tpl_enableOutfitListTemplate").val()
+    };
+    targetSettings.injectionTemplates.currentPresetId = id;
+    saveSettingsDebounced();
+    updateInjectionTemplateUI(container);
+    toastr.success(`另存为方案 "${id}" 成功！`);
+  });
+
+  container.find("#injection_template_rename").off("click").on("click", async function () {
+    const targetSettings = getCharacterSettingsRoot();
+    if (!targetSettings) return;
+    ensureInjectionTemplatesInit(targetSettings);
+
+    const oldId = targetSettings.injectionTemplates.currentPresetId || "默认方案";
+    if (oldId === "默认方案") {
+      toastr.warning("默认方案不可重命名！");
+      return;
+    }
+
+    const newName = await callGenericPopup(`重命名方案 "${oldId}" 为：`, POPUP_TYPE.INPUT, oldId);
+    if (!newName || !newName.trim() || newName.trim() === oldId) return;
+    const newId = newName.trim();
+
+    targetSettings.injectionTemplates.presets[newId] = targetSettings.injectionTemplates.presets[oldId];
+    delete targetSettings.injectionTemplates.presets[oldId];
+    targetSettings.injectionTemplates.currentPresetId = newId;
+    saveSettingsDebounced();
+    updateInjectionTemplateUI(container);
+    toastr.success("方案重命名成功！");
+  });
+
+  container.find("#injection_template_reset").off("click").on("click", async function () {
+    const confirm = await callGenericPopup("确定将当前方案恢复为系统默认模板吗？", POPUP_TYPE.CONFIRM);
+    if (!confirm) return;
+    const targetSettings = getCharacterSettingsRoot();
+    if (!targetSettings) return;
+    ensureInjectionTemplatesInit(targetSettings);
+
+    const currentId = targetSettings.injectionTemplates.currentPresetId || "默认方案";
+    targetSettings.injectionTemplates.presets[currentId] = getSystemDefaultInjectionTemplates();
+    saveSettingsDebounced();
+    updateInjectionTemplateUI(container);
+    toastr.success(`方案 "${currentId}" 已重置为系统默认！`);
+  });
+
+  container.find("#injection_template_delete").off("click").on("click", async function () {
+    const targetSettings = getCharacterSettingsRoot();
+    if (!targetSettings) return;
+    ensureInjectionTemplatesInit(targetSettings);
+
+    const currentId = targetSettings.injectionTemplates.currentPresetId || "默认方案";
+    if (currentId === "默认方案") {
+      toastr.warning("默认方案不可删除！");
+      return;
+    }
+
+    const confirm = await callGenericPopup(`确定删除方案 "${currentId}" 吗？`, POPUP_TYPE.CONFIRM);
+    if (!confirm) return;
+
+    delete targetSettings.injectionTemplates.presets[currentId];
+    targetSettings.injectionTemplates.currentPresetId = "默认方案";
+    saveSettingsDebounced();
+    updateInjectionTemplateUI(container);
+    toastr.success(`方案 "${currentId}" 已删除！`);
+  });
+}
+
 // utils/settings/character/index.js
 
 function initCharacterSettings(container) {
@@ -28120,6 +28344,7 @@ function initCharacterSettings(container) {
     setupOutfitEnableControls(container);
     setupCharacterCommonControls(container);
     setupBananaCharacterControls(container);
+    setupInjectionTemplateControls(container);
     initTagAutocomplete();
     initAllSelectSearch(container);
     isCharacterInitialized = true;

--- a/index.js
+++ b/index.js
@@ -28366,13 +28366,19 @@ function setupInjectionTemplateControls(container) {
       $lastActiveTextarea = $(this);
     });
 
-  container.find("#injection_template_insert_var_btn").off("click").on("click", function (e) {
+  container.find(".var-tab-btn").off("click").on("click", function (e) {
     e.preventDefault();
-    const varTag = container.find("#injection_template_var_select").val();
-    if (!varTag) {
-      if (typeof toastr !== "undefined") toastr.warning("请先选择要插入的占位符变量！");
-      return;
-    }
+    container.find(".var-tab-btn").removeClass("primary active");
+    $(this).addClass("primary active");
+    const tab = $(this).data("tab");
+    container.find(".var-panel").hide();
+    container.find(`#var-panel-${tab}`).css("display", "flex");
+  });
+
+  container.find(".st-chatu8-var-btn").off("click").on("click", function (e) {
+    e.preventDefault();
+    const varTag = $(this).data("var") || $(this).attr("data-var");
+    if (!varTag) return;
 
     if (!$lastActiveTextarea || $lastActiveTextarea.length === 0) {
       $lastActiveTextarea = container.find("#tpl_characterListTemplate");


### PR DESCRIPTION
## 概述与变更理由

在原有逻辑中，提示词注入格式为固定硬编码拼接，无法满足不同 LLM 对上下文结构（如 XML 节点、Markdown 卡片或原生态字段）的差异化格式需求。

本次变更将静态拼接重构为基于占位符的动态注入模板引擎，允许在 UI 界面中独立创建、编辑、导出与切换提示词注入方案，并优化了配套的空变量行清洗与别名匹配逻辑。

---

## 实际改动内容

1. 提示词注入模板自定义管理系统 (Preset Management)
- 变更理由：提供灵活的模板自定义与预设切换能力，降低不同模型格式调整的成本。
- 实际改动：在前端 HTML 与后台 JS 中新增预设 CRUD 逻辑，支持创建、保存、另存为、删除及 JSON 导入导出；预置默认方案、Tavern XML 格式与 Markdown 极简卡片格式，并建立系统预设防删与恢复机制。

2. 模板占位符解析与空变量行清洗 (applyInjectionTemplate)
- 变更理由：避免未填写的字段（如负向提示词）输出空前缀或产生无效 Token 浪费。
- 实际改动：实现占位符（如 {nameCN}, {traits}, {facial} 等）动态替换逻辑；当某行占位符变量全为空时自动擦除整行，若同行多个变量部分为空则填入 null 保持排版对齐，并自动清理下属无内容的孤立标题行。

3. 多别名拆分与触发匹配支持 (isCharacterTriggered & getTriggeredCharacterName)
- 变更理由：解决多别名识别与调试分析工具结果不一致的问题。
- 实际改动：支持使用竖线分隔多个别名并进行单独拆分匹配；在 getTriggeredCharacterName 中补充对 character.triggers 自定义触发词字段的检查，确保 Prompt 注入与调试判定一致。

4. 前端交互与实时预览面板
- 变更理由：方便编辑时快捷插入变量，并直观查看最终拼接效果。
- 实际改动：新增焦点感知下拉选单以一键插入变量；添加继承 SillyTavern UI 主题的 Live Preview 实时渲染预览框。

---

## 影响文件列表
- index.js
- html/settings/character.html
- .agents/docs/CHANGELOG_INJECTION_TEMPLATES.md
- .agents/docs/INJECTION_TEMPLATE_SPEC.md
- .agents/docs/PROJECT_REQUIREMENTS_AND_ROADMAP.md
